### PR TITLE
Draft text on C++-inspired matchertext literals

### DIFF
--- a/doc/abs.tex
+++ b/doc/abs.tex
@@ -5,14 +5,23 @@ but usually requires tedious and error-prone
 ``escaping'' transformations on the embedded string.
 We propose a simple cross-language syntactic discipline,
 \emph{matchertext},
-which enables the safe embedding a string in any compliant language
-into a string in any other language via simple ``copy-and-paste'' --
-in particular with no escaping, obfuscation, or expansion of embedded strings.
-We apply this syntactic discipline
+embodied in the single rule that \emph{matchers must match} --
+where \emph{matchers} are the ASCII character pairs
+\verb|()|, \verb|[]|, and \verb|{}|.
+This discipline
+enables the safe embedding any matchertext-compliant string
+into any matchertext-aware language via simple ``copy-and-paste'' --
+with no escaping, obfuscation, or expansion of embedded strings.
+Simple string-literal syntax extensions like \verb|M"(|$\dots$\verb|)"|,
+backward-compatible with a wide variety of languages,
+could enable the robust embedding of arbitrary matchertext strings
+consistently without escaping.
+We apply this syntactic discipline experimentally
 to several common and frequently-embedded
 language syntaxes such as URIs, HTML, and JavaScript,
 exploring the benefits, costs, and compatibility issues
 in adopting the proposed matchertext discipline.
-One early matchertext-based language is MinML,
-a concise but general alternative syntax for writing HTML or XML.
+We also bpresent MinML,
+an experimental markup syntax designed around matchertext,
+as a concise but general alternative syntax for writing HTML or XML.
 \end{abstract}

--- a/doc/abs.tex
+++ b/doc/abs.tex
@@ -21,7 +21,7 @@ to several common and frequently-embedded
 language syntaxes such as URIs, HTML, and JavaScript,
 exploring the benefits, costs, and compatibility issues
 in adopting the proposed matchertext discipline.
-We also bpresent MinML,
+We also present MinML,
 an experimental markup syntax designed around matchertext,
 as a concise but general alternative syntax for writing HTML or XML.
 \end{abstract}

--- a/doc/bg.tex
+++ b/doc/bg.tex
@@ -5,7 +5,7 @@ The practice of
 embedding strings from one language into another
 is ubiquitous --
 as is the pain of having to ``escape'' embedded strings
-to protect them from misinterpretation by the host language processor.
+to protect them from misinterpretation by the host-language processor.
 This section briefly explores a few of these common existing practices
 and the syntactic composition problems they create.
 
@@ -115,6 +115,10 @@ surround a quoted sequence with a balanced number of \verb|#| signs:
 \href{https://www.lua.org/manual/5.1/manual.html}{Lua}
 similarly offers \emph{long bracket} quotations
 like \verb|[=[|$\dots$\verb|]=]|, \verb|[==[|$\dots$\verb|]==]|, etc.
+C++ supports raw-string literals of the form
+\verb|R"|$d$\verb|(|$\dots$\verb|)|$d$\verb|"|,
+where $d$ is a nearly-arbitrary \emph{delimiter string}
+to make the opener and closer sequence as unique as may be needed.
 This approach has the appeal that for any string to be delimited,
 there always \emph{exists} some delimiter pair
 that can quote it unambiguously.

--- a/doc/concl.tex
+++ b/doc/concl.tex
@@ -17,7 +17,13 @@ in order to evaluate its benefits and costs empirically.
 
 \subsection*{Acknowledgments}
 
-I wish to thank Terence Parr and Russ Cox
+I wish to thank
+Antoine Bastide,
+Henry Corrigan-Gibbs,
+Russ Cox,
+Philip Hamelink,
+and
+Terence Parr
 for valuable feedback on earlier drafts of this paper.
 
 \xxx{samller contributions and funding acknowledgments here}

--- a/doc/design.tex
+++ b/doc/design.tex
@@ -109,7 +109,7 @@ or restrictions (\eg disallowing certain characters or sequences)
 within the embedded matchertext it is hosting.
 We can view embedded matchertext as analogous to a diplomatic embassy,
 whose host country is required by international law to respect and protect
-the ``involability'' of the embassy's ``premises''
+the ``inviolability'' of the embassy's ``premises''
 and not enter or otherwise meddle in
 the embassy's internal affairs~\cite[Article 22]{un61vienna}.
 Beyond the matchertext rule that ASCII matchers must match,
@@ -150,7 +150,7 @@ In fact, the programming language community has also largely converged
 on UTF-8 as the standard way to encode UCS plain text
 into flat byte-stream source files --
 although encoding is not a primary concern for matchertext
-since it operates below the character set abstraction.
+since it operates below the character-set abstraction.
 
 \subsubsection{Standardizing on matcher pairs}
 \label{sec:design:concrete:standard}

--- a/doc/embed.tex
+++ b/doc/embed.tex
@@ -9,7 +9,7 @@ overlaps heavily with those of interest as host languages;
 we separate these discussions mainly to emphasize the orthogonality
 of host- and embedded-language issues and cleanly separate them.
 
-It is already readily feasible to write valid matchertext
+It is already entirely feasible to write valid matchertext
 in most of the languages we will consider for embedding.
 This is because most popular machine-readable languages
 already largely conform to the ``matchers must match'' rule
@@ -25,7 +25,7 @@ and are by no means essential.
 
 Almost certainly the most common context in which unmatched matchers
 appear in most today's existing source code is within string literals.
-This is especially true of code to print, or parse,
+This is especially true of code designed to print, or parse,
 machine-readable code in almost any syntax.
 Structured pretty-printing code frequently includes code sequences like this:
 
@@ -233,7 +233,7 @@ Smart text editors often try to detect URIs on entry
 and automatically turn them into hyperlinks --
 but these heuristics can easily break because
 there is no unambiguous syntactic separation between the URI
-from surrounding (particularly following) text.
+and its surrounding (particularly following) text.
 Suppose for example that I type or copy this text into an E-mail:
 
 \begin{footnotesize}
@@ -317,7 +317,8 @@ the MRI `\verb|http://ip6[1234::abcd]:80/|'.
 %could avoid obfuscation in URIs~\cite{rfc6874}:
 %the URI `\verb|http://[1234::abcd%25eth0]/' becomes
 %the MRI `\verb|http://ip6[1234::abcd%eth0]/'.
-The MRI host field syntax thus knows only about domain names or nested MRIs,
+The MRI host field syntax thus needs to know
+only about domain names or nested MRIs,
 and not about IP address syntax.
 
 

--- a/doc/host.tex
+++ b/doc/host.tex
@@ -137,48 +137,59 @@ either or both of these extensions independently.
 
 A \emph{matchertext literal} is a string literal
 whose content is entirely matchertext.
-One syntax we suggest for matchertext literals
-is \verb|M"(|$\dots$\verb|)"|,
-inspired by C++ raw-string syntax \verb|R"(|$\dots$\verb|)"|.
-The content of such a matchertext literal
-must be valid matchertext (matchers must match),
+We suggest that languages allow mtchertext literals of the form
+\verb|M"(|$m$\verb|)"|,
+\verb|M"[|$m$\verb|]"|, and
+\verb|M"{|$m$\verb|}"|,
+where the substring $m$ is arbitrary matchertext.
+The content $m$ of such a matchertext literal
+\emph{must} be valid matchertext (matchers must match),
 otherwise the language processor reports a syntax error.
 Any matchertext string may be embedded verbatim in such a literal
-without exceptions or escaping, however.
+without exceptions or escaping.
 
-The parentheses in this syntax could be replaced with brackets or braces,
-or a particular language could even allow any of the three matcher pairs.
-We suggest the use of parentheses as the standard
-partly for consistency with the C++ inspiration,
-and partly due to the traditional use of parentheses for grouping.
-The use of \emph{some} matcher pair in this syntax is necessary
-for hosting arbitrary matchertext strings without escaping, however:
-the sole use of double-quotes as in \verb|M"|$\dots$\verb|"|, for example,
+We could prescribe the use in this syntax
+of one particular matcher pair of the three,
+but doing so seems unnecessary,
+since the leading \verb|M| identifies the literal as hosting matchertext.
+The first alternative using parentheses is stylistically closest to,
+and inspired by,
+C++ raw-string syntax \verb|R"(|$\dots$\verb|)"|.
+The second alternative using square brackets
+is stylistically more consistent with other matchertext extensions we suggest
+such as the one below in \cref{sec:host:c:escapes}, however.
+We see no obvious reason not to leave the choice of matcher to the user
+in this case.
+
+The use of \emph{some} matcher pair in this syntax is necessary,
+in any event,
+for hosting arbitrary matchertext strings this way without escaping.
+The sole use of double-quotes as in \verb|M"|$m$\verb|"|, for example,
 would not be fully robust or general
 because ASCII double quotes do not come in matched pairs,
-as further discussed below.
+as further discussed below in \cref{sec:host:c:other}.
 
-If we establish \verb|M"(|$\dots$\verb|)"|
+If we try to establish the above
 as a cross-language syntactic standard for matchertext literals,
-then we might leave variants like the lower-case version \verb|m"|$\dots$\verb|"|
+then we leave variants like the lower-case version \verb|m"|$m$\verb|"|
 for individual languages to decide the meaning of, if any.
-Some language-specific choices include:
+Such language-specific choices include:
 (a) no lower-case variant (syntax error);
-(b) \verb|m"(|$\dots$\verb|)"| is equivalent to \verb|M"(|$\dots$\verb|)"|;
-\ie the \verb|m| is simply case-insensitive;
-(c) \verb|m"|$\dots$\verb|"| without parentheses
+(b) \verb|m"(|$m$\verb|)"| is equivalent to \verb|M"(|$m$\verb|)"|;
+\ie the \verb|M| is simply case-insensitive;
+(c) \verb|m"|$m$\verb|"| without a matcher pair around the content $m$
 might be a constrained, shorthand syntax
-usable only for matchertext strings that contain no double-quotes
+usable only for matchertext strings $m$ that contain no double-quotes
 outside of matcher pairs; or
-(d) \verb|m"|$\dots$\verb|"| is a ``hybrid'' syntax
+(d) \verb|m"|$m$\verb|"| might be a ``hybrid'' syntax
 in which the host language's usual escaping mechanisms are active
-outside of matcher pairs within the embedded strings
-(hence allowing any matchertext string to be represented
+outside of matcher pairs within the embedded string,
+hence allowing any matchertext string to be represented
 at the cost of allowing the host language's escaping to ``leak''
-into the outermost context of the embedded string).
-Options (a) and (b) obviously appear simpler and cleaner,
-with (c) and (d) suggested only as potential alternatives
-that might optimize different pragmatic tradeoffs.
+into the outermost context of the embedded string.
+Options (a) and (b) appear conceptually simpler and cleaner,
+with (c) and (d) mentioned mainly as potential alternatives
+that could optimize different pragmatic tradeoffs.
 
 
 \subsubsection{Matchertext escapes in ordinary string literals}
@@ -230,6 +241,7 @@ ASCII matchers must match.
 
 
 \subsubsection{Other syntactic alternatives}
+\label{sec:host:c:other}
 
 The above proposals are only two of many possible alternatives of course,
 which may be worth considering --

--- a/doc/host.tex
+++ b/doc/host.tex
@@ -126,9 +126,68 @@ are the primary existing syntactic mechanism
 for embedding (non-matchertext) strings traditionally,
 they represent a natural starting point for considering matchertext extensions.
 
-Given the ubiquity of backslash-escaped string literals,
-we suggest that one reasonable extension for hosting matchertext
-in C-like languages is via a new escape sequence,
+We propose two potential extensions to C-like languages
+for hosting arbitrary matchertext:
+\emph{matchertext literals} and \emph{matchertext escapes}.
+Any language could adopt
+either or both of these extensions independently.
+
+\subsubsection{Matchertext literals}
+\label{sec:host:c:literals}
+
+A \emph{matchertext literal} is a string literal
+whose content is entirely matchertext.
+One syntax we suggest for matchertext literals
+is \verb|M"(|$\dots$\verb|)"|,
+inspired by C++ raw-string syntax \verb|R"(|$\dots$\verb|)"|.
+The content of such a matchertext literal
+must be valid matchertext (matchers must match),
+otherwise the language processor reports a syntax error.
+Any matchertext string may be embedded verbatim in such a literal
+without exceptions or escaping, however.
+
+The parentheses in this syntax could be replaced with brackets or braces,
+or a particular language could even allow any of the three matcher pairs.
+We suggest the use of parentheses as the standard
+partly for consistency with the C++ inspiration,
+and partly due to the traditional use of parentheses for grouping.
+The use of \emph{some} matcher pair in this syntax is necessary
+for hosting arbitrary matchertext strings without escaping, however:
+the sole use of double-quotes as in \verb|M"|$\dots$\verb|"|, for example,
+would not be fully robust or general
+because ASCII double quotes do not come in matched pairs,
+as further discussed below.
+
+If we establish \verb|M"(|$\dots$\verb|)"|
+as a cross-language syntactic standard for matchertext literals,
+then we might leave variants like the lower-case version \verb|m"|$\dots$\verb|"|
+for individual languages to decide the meaning of, if any.
+Some language-specific choices include:
+(a) no lower-case variant (syntax error);
+(b) \verb|m"(|$\dots$\verb|)"| is equivalent to \verb|M"(|$\dots$\verb|)"|;
+\ie the \verb|m| is simply case-insensitive;
+(c) \verb|m"|$\dots$\verb|"| without parentheses
+might be a constrained, shorthand syntax
+usable only for matchertext strings that contain no double-quotes
+outside of matcher pairs; or
+(d) \verb|m"|$\dots$\verb|"| is a ``hybrid'' syntax
+in which the host language's usual escaping mechanisms are active
+outside of matcher pairs within the embedded strings
+(hence allowing any matchertext string to be represented
+at the cost of allowing the host language's escaping to ``leak''
+into the outermost context of the embedded string).
+Options (a) and (b) obviously appear simpler and cleaner,
+with (c) and (d) suggested only as potential alternatives
+that might optimize different pragmatic tradeoffs.
+
+
+\subsubsection{Matchertext escapes in ordinary string literals}
+\label{sec:host:c:escapes}
+
+Given the ubiquity of backslash-escaped string literals in C-like languages,
+another potential extension for hosting matchertext in such languages
+is via a new escape sequence
+usable within \emph{ordinary} string literals,
 such as \verb|\[|$m$\verb|]|,
 where $m$ is arbitrary matchertext.
 The embedded matchertext $m$ is uninterpreted by the host language processor
@@ -138,14 +197,41 @@ Thus, quote characters, backslashes, whitespace, newlines,
 or other control codes cease being ``special'' within the matchertext $m$ --
 at least from the perspective of the host language.
 For example, the string literal \verb|"\["'\]"|
-becomes equivalent to \verb|"\"\'\\"|.
+becomes equivalent to \verb|"\"\'\\"| using conventional escaping.
 These and other characters might of course be ``special'' with respect to
 whatever embedded language $m$ might be written in.
 
+Embedding matchertext in a string literal via a new escape sequence
+has the advantage that the \emph{entire} literal need not be matchertext.
+Literals can mix matchertext with conventional literal text
+including host-language escape sequences:
+\eg \verb|"\t\[let's indent]\n\t\[a "quote"]"|.
 
-\subsubsection{Some syntactic alternatives}
+The choice of square brackets for the proposed matchertext escape sequence
+is somewhat arbitrary:
+we could instead use use parentheses or curly braces,
+or a longer sequence such as \verb|\m[|$m$\verb|]|.
+Any choice may conflict with existing syntax in \emph{some} language:
+\eg
+\verb|\(|$m$\verb|)| conflicts with
+\href{https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html#ID292}{string interpolation in Swift},
+\verb|\[|$m$\verb|]| conflicts with
+\href{https://www.php.net/manual/en/language.types.string.php}{octal character escapes in PHP},
+and
+\verb|\{|$m$\verb|}| conflicts with
+\href{https://ceylon-lang.org/documentation/1.3/reference/literal/string/}{Unicode escapes in Ceylon}.
+Fortunately, different languages need not agree on
+the precise syntax for hosting matchertext strings,
+and can choose whatever syntax best suits that particular language.
+To fulfill matchertext's main objective,
+different languages need to agree \emph{only} on the basic rule
+that the embedded string itself is arbitrary except that
+ASCII matchers must match.
 
-The above proposal is only one of many possible alternatives of course,
+
+\subsubsection{Other syntactic alternatives}
+
+The above proposals are only two of many possible alternatives of course,
 which may be worth considering --
 especially in the context of specific programming languages.
 We now briefly discuss a few ``obvious'' alternatives
@@ -196,33 +282,6 @@ only pushes these syntactic conflicts deeper
 Considering the other ASCII matchers (parentheses or curly braces)
 does not improve the situation much.
 
-Embedding matchertext in a string literal via a new escape sequence
-also has the advantage that the \emph{entire} literal need not be matchertext.
-Literals can mix matchertext with conventional literal text
-including host-language escape sequences:
-\eg \verb|"\t\[let's indent]\n\t\[a "quote"]"|.
-
-The choice of square brackets for the proposed matchertext escape sequence
-is somewhat arbitrary:
-we could instead use use parentheses or curly braces,
-or a longer sequence such as \verb|\m[|$m$\verb|]|.
-Any choice may conflict with existing syntax in \emph{some} language:
-\eg
-\verb|\(|$m$\verb|)| conflicts with
-\href{https://docs.swift.org/swift-book/LanguageGuide/StringsAndCharacters.html#ID292}{string interpolation in Swift},
-\verb|\[|$m$\verb|]| conflicts with
-\href{https://www.php.net/manual/en/language.types.string.php}{octal character escapes in PHP},
-and
-\verb|\{|$m$\verb|}| conflicts with
-\href{https://ceylon-lang.org/documentation/1.3/reference/literal/string/}{Unicode escapes in Ceylon}.
-Fortunately, different languages need not agree on
-the precise syntax for hosting matchertext strings,
-and can choose whatever syntax best suits that particular language.
-To fulfill matchertext's main objective,
-different languages need to agree \emph{only} on the basic rule
-that the embedded string itself is arbitrary except that
-ASCII matchers must match.
-
 
 \subsection{SGML-style markup host languages}
 \label{sec:host:ml}
@@ -261,7 +320,7 @@ there are at least three different syntactic contexts
 in which strings in other languages are often embedded
 into \ml languages --
 and in which three different sets of quoting and escaping rules apply.
-Embedded strings are often embedded
+Strings are often embedded
 (1) as the content of an element,
 (2) as an attribute within an element's start tag, or
 (3) as verbatim text within a CDATA section.
@@ -795,7 +854,7 @@ the pathological ``\href{https://en.wikipedia.org/wiki/Leaning_toothpick_syndrom
 matching the double-backslash \verb|\\| in a UNC name (see \cref{sec:bg}),
 becomes the more readable RE \verb|{{\\}}|.
 Embedding this RE in a C-like string literal with matchertext extensions
-in turn becomes \verb|"\[{{\\}}]"|,
-for a more manageable three leaning toothpicks total,
-in contrast with the traditionally-required eight (\verb|"\\\\\\\\"|).
+in turn becomes \verb|M"({{\\}})"| or \verb|"\[{{\\}}]"|,
+for a more manageable two or three leaning toothpicks,
+in contrast with the traditionally-required eight in \verb|"\\\\\\\\"|.
 

--- a/doc/host.tex
+++ b/doc/host.tex
@@ -870,3 +870,192 @@ in turn becomes \verb|M"({{\\}})"| or \verb|"\[{{\\}}]"|,
 for a more manageable two or three leaning toothpicks,
 in contrast with the traditionally-required eight in \verb|"\\\\\\\\"|.
 
+
+\subsection{Matchertext string interpolation}
+\label{sec:host:interp}
+
+All the above sections have focused on the problem of
+hosting arbitrary matchertext strings, \emph{verbatim},
+while eliminating the need for escaping.
+We have thus assumed so far that the desire is
+for the semantic value of a string literal
+(the ``output'' from scanning the literal)
+should ideally be identical to and unmodified from the literal's ``input''
+(the ``input'' character sequence between the literal's delimiters) --
+and the matchertext discipline indeed makes this goal achievable.
+
+The string-literal syntax in many programming and scripting languages,
+however,
+often and increasingly support \emph{string interpolation}:
+the substitution of strings residing in variables, function parameters,
+or even computed by arbitrary host-language expressions,
+to be substituted into explicit ``holes''
+in an otherwise-verbatim string literal.
+If \verb|name| is a variable containing the string `\verb|Bob|',
+for example,
+then to construct the string `\verb|Hi Bob|',
+instead of manual concatenation via an expression like
+\verb|"Hi "+name|,
+one may instead write
+\verb|f'Hi {name}'| in Python,
+\verb|'Hi ${name}'| in JavaScript,
+\verb|"Hi #{name}"| in Ruby,
+\verb|"Hi \(name)"| in Swift,
+or just
+\verb|"Hi $name"| in many shells and scripting languages
+such as Bash, Perl, and PHP.
+
+String interpolation extends the functional role of string literals
+from verbatim string \emph{expression}
+to template-based string \emph{processing}:
+automating the concatenation of verbatim and computed strings
+to form a result.
+It may at first appear that matchertext hosting and string interpolation
+are incompatible,
+since our matchertext goal has mostly been to \emph{avoid modifying}
+strings we wish to express verbatim,
+while string interpolation's goal is precisely to \emph{modify}
+a template string by filling holes in well-defined ways.
+Indeed, if we are to have any way to specify
+a hole to be filled in a template,
+allowing that hole to be \emph{anywhere} in the string,
+then it appears we \emph{must} make some character sequences in the template
+sensitive, and thus forbidden or escaped in verbatim text
+(\eg the `\verb|$|' that introduces interpolated variable names
+in many scripting languages).
+
+There is nevertheless a different role that matchertext might usefully play
+in conjunction with string interpolation:
+namely defining and enforcing a hierarchical notion of
+\emph{structural integrity} during interpolation.
+This alternative role could be especially important for security,
+where traditional string interpolation
+based on structure-oblivious concatenation
+has been at least partly responsible for an enormous number
+of critical security bugs historically,
+starting with the quintessential SQL injection attack~\cite{clarke12sql}.
+\xxx{specific example?}
+We therefore propose below potential matchertext-aware extensions
+that support string interpolation while ensuring structural integrity.
+
+\subsubsection{Interpolation in matchertext literals}
+\label{sec:host:interp:lit}
+
+We suggest a potential string-interpolation extension
+to the cross-language matchertext literal syntax
+described above in \cref{sec:host:c:literals}.
+An \emph{interpolating} matchertext literal has the form
+\verb|M|$d$\verb|"(|$m$\verb|)"|,
+\verb|M|$d$\verb|"[|$m$\verb|]"|, or
+\verb|M|$d$\verb|"{|$m$\verb|}"|,
+where $d$ is a \emph{delimiter string}
+consisting solely of one or more strictly-nested matcher pairs
+specifying the delimiters to be used to express holes or \emph{antiquotations}
+within the literal.
+In this syntax, for example,
+several equivalent ways to express the interpolation example above
+would be
+\verb|M{}"(Hi {name})"|,
+\verb|M[]"{Hi [name]}"|,
+\verb|M()"(Hi (name))"|,
+\verb|M{{}}"[Hi {{name}}]"|, or
+\verb|M([{}])"[Hi ([{name}])]"|.
+
+The intent of this string-interpolation syntax
+goes beyond merely ``filling in holes'' in a template, however.
+The expectation is that not just the template itself,
+but also all of the interpolated hole-filling strings,
+\emph{must} be matchertext-compliant:
+otherwise the interpolation processing yields
+some error whose reporting and handling is language-dependent.
+If the variable \verb|name| contains
+the non-matchertext string `\verb|Eve(|', for example,
+then the interpolation in the above example fails with an error,
+and in particular does \emph{not} just ``blindly'' use concatenation
+to produce the string `\verb|Hi Eve(|'.
+
+Enforcing matchertext discipline on both the template
+and the interpolated strings
+ensures that the result is valid matchertext,
+and more generally ensures that interpolated strings
+cannot compromise the hierarchical structure of the template.
+This property can be useful as a security measure,
+since a vast number of critical SQL injection attacks
+and other input-validation attacks, historically,
+have relied on violating the structure of an interpolated template.
+In many SQL injection attacks, for example,
+an insufficiently-constrained user-entered string
+interpolated into an SQL query between quotes
+might contain a quote mark that gets interpreted
+as an ``early'' close quote followed by arbitrary attack code
+that gets executed as SQL code on the server side.
+Using matchertext literals and interpolation
+instead of conventional literals
+could thus provide a layer of protection against such attacks
+below and independent of
+the complex language-dependent parsing and string-handling code.
+In essence, matchertext interpolation could be viewed
+as ``microsegmentation of text-based formats'',
+anologous to the already-accepted best practice
+of microsegmentation of networks.
+
+Error handling is necessarily language-dependent, of course,
+and we expect should match the conventions of a given language.
+Languages like Java that support exception handling
+might use those to handle matchertext interpolation errors,
+for example.
+We might envision future strongly-typed languages
+having a \verb|matchertext| type representing a string
+that is statically known to be valid matchertext,
+either as a result of how it was produced
+or by an explicit check for example.
+
+In some contexts it may be undesirable or impossible
+for a matchertext interpolation error to affect control flow.
+An alternative in such cases might be for matchertext interpolation
+to replace any non-matchertext strings with
+a single Unicode replacement character (U+FFFD),
+whose standardized purpose is to serve as an explicit placeholder
+for something invalid or non-representable.
+This approach makes interpolation errors ``silent'',
+while at least ensuring that the interpolated result
+is still valid matchertext,
+preserves the template's hierarchical structure,
+and that the interpolated replacement character
+is unlikely to be interpreted as useful ``code''
+an attacker might make use of in practically any conceivable language.
+
+\xxx{also talk about language-specific hybrid variants
+	such as m"..." in which the host language's
+	escaping and interpolation syntax apply within the template?
+}
+
+\subsubsection{Hybrid matchertext interpolation}
+\label{sec:host:interp:hybrid}
+
+The above matchertext interpolation syntax
+is suggest as one that appears likely backward-compatible
+with a large number of existing languages,
+and could help provide some cross-language consistency if adopted.
+Many languages already have their own well-defined
+interpolation syntax, however,
+sometimes related to the host language's normal escaping syntax
+as in Swift's interpolation escapes like \verb|\(name)| in string literals.
+Since a template for interpolation is intended for modification anyway,
+avoiding the need for escapes or other ``sensitive'' characters
+in such templates is unavoidable and hence arguably less important
+than when using literals for verbatim embedding.
+
+As a result, there may be a pragmatic argument
+for languages to offer \emph{hybrid} matchertext interpolation syntax,
+which enforces the matchertext structural discipline (\eg for security),
+but maintains the host language's normal escaping and interpolation syntax.
+In Python, for example,
+an extension might support syntax like \verb|m'Hi {name}'|,
+where exactly the same interpolation and escaping syntax
+apply within the quotes
+as with Python's existing \verb|f'Hi {name}'| syntax --
+except that the matchertext syntax ensures that
+the template, all interpolated strings,
+and the output are all valid matchertext.
+

--- a/doc/host.tex
+++ b/doc/host.tex
@@ -137,7 +137,7 @@ either or both of these extensions independently.
 
 A \emph{matchertext literal} is a string literal
 whose content is entirely matchertext.
-We suggest that languages allow mtchertext literals of the form
+We suggest that languages allow matchertext literals of the form
 \verb|M"(|$m$\verb|)"|,
 \verb|M"[|$m$\verb|]"|, and
 \verb|M"{|$m$\verb|}"|,

--- a/doc/intro.tex
+++ b/doc/intro.tex
@@ -168,7 +168,17 @@ for the forbidden host-language delimeters,
 and changing the delimeters or awkwardly rewriting the embedded text
 (\eg by concatenating multiple strings in different quoting styles).
 Matchertext, in contrast, forbids \emph{no} characters or sequences
-in embedded strings provided only that matchers match.
+in embedded strings,
+provided only that matchers match.
+Building on and adapting the raw-string tradition,
+another widely-backward-compatible approach to hosting matchertext
+is to add support for \emph{matchertext string literals}
+like \verb|M"(|$\dots$\verb|)"| to languages,
+stylistically similar to the raw-string syntax \verb|R"(|$\dots$\verb|)"| 
+already in C++.
+In this matchertext-literal syntax,
+the above regular-expression example
+would be \verb|re.match(M"("[^"]*")")|.
 
 It is already feasible to write code in existing languages
 that is also valid matchertext,
@@ -239,7 +249,7 @@ as in \verb|printf("\x7B")| or \verb|case "\x5D"| for example.
 Backward-compatible language extensions might ease this pain,
 however, 
 with new escape sequences that include \emph{both} matchers of a pair
-but select only the opener or closer.
+but select only the pair's opener or closer.
 The proposed new escape \verb|\o()| represents a literal open parenthesis,
 for example,
 while \verb|\c[]| represents a close bracket.


### PR DESCRIPTION
Based on our discussion so far, this draft modification to the matchertext preprint specifies and discusses C++-inspired matchertext literal syntax like `M"(...)"`.

Python-style matchertext literals without the parentheses (or any matcher pair) in the syntax like `m"..."` is more problematic for reasons also briefly discussed in the document, but comments/ideas welcome.