### PR TITLE
fix: unignore minml directory and fix compilation error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/.DS_Store
 **/.idea
-**/minml
+/minml
 **/minml.exe
 out/wasm/main.wasm
 out/wasm/wasm_exec.js

--- a/go/markup/minml/cmd/server.go
+++ b/go/markup/minml/cmd/server.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"github.com/dedis/matchertext/go/markup/minml"
 	"io/fs"
 	"log"
 	"net/http"
@@ -15,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/dedis/matchertext/go/markup/minml"
 
 	"github.com/dedis/matchertext/go/markup/minml/cmd/server_structs"
 	"github.com/fsnotify/fsnotify"
@@ -233,17 +233,17 @@ func convertFile(target server_structs.BuildTarget, relPath string, extensions [
 	}
 
 	// Convert MinML to HTML
-	var buf bytes.Buffer
-	if err := minml.ConvertFromReader(bytes.NewReader(data), &buf, relPath); err != nil {
+	html, err := minml.ConvertString(string(data))
+	if err != nil {
 		return fmt.Errorf("converting %s: %w", relPath, err)
 	}
 
 	// Inject live-reload script
-	buf.WriteString(reloadScript)
+	html += reloadScript
 
 	// Write HTML output to the build target
 	htmlPath := relPath[:len(relPath)-len(extension)] + "html"
-	if err := target.WriteFile(htmlPath, buf.Bytes()); err != nil {
+	if err := target.WriteFile(htmlPath, []byte(html)); err != nil {
 		return fmt.Errorf("writing %s: %w", htmlPath, err)
 	}
 


### PR DESCRIPTION
While working on my [Docker wrapper fork](https://github.com/MaelImhof/matchertext-container), I noticed the Go parser (`make build`) was not successfully built anymore, instead, I got:

```
go/markup/minml/cmd/server.go:237:18: undefined: minml.ConvertFromReader
```

It happened right after I merged changes from #7 into my fork. Maybe `server.go` was supposed to be updated, but wasn't because of `.gitignore`?

Feel free to directly edit this PR directly or ask me to change things.

## Change Log

- Proposed fix for the compilation error in `go/markup/minml/cmd/server.go`
- Modified `.gitignore` so that only the root `minml` executable is ignored, not all subdirectories named `minml`