### PR TITLE
Add string to MatcherText conversion stats

### DIFF
--- a/LLVM/CMakeLists.txt
+++ b/LLVM/CMakeLists.txt
@@ -151,6 +151,41 @@ add_test(NAME debug_language_output
     ${CMAKE_SOURCE_DIR}/tests/string_bucket_mix.cpp
     ${CMAKE_BINARY_DIR}/debug-language-output)
 
+add_executable(StringLiteralDecodeTests
+    tests/string_literal_decode_test.cpp
+    src/Parser.cpp
+    src/EmbeddedStats.cpp
+    src/NestedStats.cpp
+    src/Stats.cpp
+    src/FileStats.cpp
+    src/LanguageClassifier.cpp
+    ${CLASSIFIER_SOURCES}
+    src/LanguageStats.cpp
+    include/Parser.hpp
+    include/EmbeddedStats.hpp
+    include/NestedStats.hpp
+    include/Stats.hpp
+    include/MatcherText.hpp
+    include/AtomicString.hpp
+    include/FileStats.hpp
+    include/StatsGenerator.hpp
+    include/LanguageClassifier.hpp
+    include/LanguageStats.hpp
+    include/LanguageModel.generated.hpp
+    src/LanguageParser.cpp
+    include/LanguageParser.hpp
+    include/LanguageData.hpp
+)
+target_include_directories(StringLiteralDecodeTests PRIVATE include)
+target_link_libraries(StringLiteralDecodeTests clangLex clangBasic)
+if (OpenMP_CXX_FOUND)
+    target_compile_definitions(StringLiteralDecodeTests PRIVATE USE_OPENMP=1)
+    target_link_libraries(StringLiteralDecodeTests OpenMP::OpenMP_CXX)
+else ()
+    target_compile_definitions(StringLiteralDecodeTests PRIVATE USE_OPENMP=0)
+endif ()
+add_test(NAME string_literal_decode COMMAND StringLiteralDecodeTests)
+
 # === LLVM & Clang ===
 find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
@@ -197,6 +232,7 @@ target_link_libraries(${PROJECT_NAME} Serde)
 target_link_libraries(LanguageClassifierTests Serde)
 target_link_libraries(ParserFixtureTests Serde)
 target_link_libraries(DebugLanguageOutputTests Serde)
+target_link_libraries(StringLiteralDecodeTests Serde)
 
 # --------------------------
 # Build Configs

--- a/LLVM/clone-orgs.sh
+++ b/LLVM/clone-orgs.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# clone-orgs.sh — clone every (non-archived) repository in one or more GitHub
+# orgs in parallel, designed to stay well under GitHub's API and abuse limits.
+#
+# Usage:
+#   ./clone-orgs.sh [-o <output-dir>] <org1> [<org2> ...]
+#
+# Args / flags:
+#   -o, --output DIR  output root directory (overrides $OUTPUT, default ./repos)
+#
+# Tunables (env vars; flag wins if both are set):
+#   JOBS          parallelism (default 8 ; >16 starts tripping secondary
+#                 abuse limits and disk I/O caps the benefit anyway)
+#   DEPTH         shallow-clone depth   (default 1 ; set 0 for full history)
+#   OUTPUT        output root dir       (default ./repos)
+#   SKIP_ARCHIVED skip archived repos   (default 1)
+#   SKIP_FORKS    skip forked repos     (default 0)
+#   RETRIES       per-repo retry count  (default 3, exponential backoff)
+#
+# Requirements: gh (authenticated — run `gh auth login` once), git, jq.
+# For private repos also run `gh auth setup-git` so plain `git clone` picks
+# up the gh token via git's credential helper.
+#
+# Rate-limit strategy:
+#   1. `gh repo list` uses GraphQL and paginates internally → cheapest per
+#      repo on the metadata side.
+#   2. `git clone` over HTTPS is rate-limited *separately* from the REST/
+#      GraphQL quotas, with much more lenient ceilings, so the clone storm
+#      doesn't touch the 5000/hr API budget.
+#   3. JOBS bounds in-flight HTTPS connections to a number GitHub tolerates
+#      without secondary throttling.
+#   4. Failures are retried with quadratic backoff (2 s, 8 s, 18 s …).
+
+set -euo pipefail
+
+JOBS=${JOBS:-8}
+DEPTH=${DEPTH:-1}
+OUTPUT=${OUTPUT:-./repos}
+SKIP_ARCHIVED=${SKIP_ARCHIVED:-1}
+SKIP_FORKS=${SKIP_FORKS:-0}
+RETRIES=${RETRIES:-3}
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+log() { printf '%s\n' "$*" >&2; }
+usage() { die "usage: $0 [-o <output-dir>] <org> [<org> ...]"; }
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    -o|--output)
+      [ $# -ge 2 ] || usage
+      OUTPUT=$2; shift 2 ;;
+    --output=*)
+      OUTPUT=${1#*=}; shift ;;
+    -h|--help)
+      usage ;;
+    --)
+      shift; break ;;
+    -*)
+      die "unknown flag: $1" ;;
+    *)
+      break ;;
+  esac
+done
+
+[ $# -ge 1 ] || usage
+
+command -v gh  >/dev/null || die "gh CLI not found (https://cli.github.com/)"
+command -v git >/dev/null || die "git not found"
+command -v jq  >/dev/null || die "jq not found"
+gh auth status >/dev/null 2>&1 || die "not authenticated — run: gh auth login"
+
+remaining=$(gh api rate_limit -q '.resources.core.remaining' 2>/dev/null || echo 0)
+log "GitHub REST budget: ${remaining}/5000 remaining"
+[ "${remaining}" -ge 100 ] || die "REST budget too low (${remaining}); wait or use a different token"
+
+mkdir -p "${OUTPUT}"
+
+# Build a jq filter that conditionally drops archived / fork repos.
+jq_filter='.[]'
+[ "${SKIP_ARCHIVED}" = 1 ] && jq_filter="${jq_filter} | select(.isArchived | not)"
+[ "${SKIP_FORKS}"    = 1 ] && jq_filter="${jq_filter} | select(.isFork    | not)"
+jq_filter="${jq_filter} | \"\\(.owner.login)/\\(.name)\""
+
+list_repos() {
+  local org=$1
+  log "listing: ${org}"
+  gh repo list "${org}" \
+    --limit 100000 \
+    --json name,owner,isArchived,isFork \
+    -q "${jq_filter}"
+}
+
+ALL_REPOS=$(mktemp -t clone-orgs.XXXXXX)
+trap 'rm -f "${ALL_REPOS}"' EXIT
+
+for org in "$@"; do
+  list_repos "${org}" >> "${ALL_REPOS}" || log "warning: skipping ${org} (listing failed)"
+done
+
+total=$(wc -l < "${ALL_REPOS}" | tr -d ' ')
+log "queued ${total} repos across $# org(s); JOBS=${JOBS}, DEPTH=${DEPTH}, OUTPUT=${OUTPUT}"
+[ "${total}" -gt 0 ] || { log "nothing to clone"; exit 0; }
+
+CLONE_LOG="${OUTPUT}/clone.log"
+: > "${CLONE_LOG}"
+
+# Per-repo worker: skip-if-exists, clone, retry on failure with quadratic
+# backoff. Records its outcome in CLONE_LOG (one short line, append is atomic
+# for the lengths used here) and stays silent on stdout so the progress bar
+# rendered by the watcher below is the only thing on the user's terminal.
+# Always returns 0 so a single bad repo doesn't sink the batch.
+clone_one() {
+  local slug=$1
+  local dest="${OUTPUT}/${slug}"
+  local outcome
+
+  if [ -d "${dest}/.git" ]; then
+    outcome="SKIP  ${slug}"
+  else
+    mkdir -p "$(dirname "${dest}")"
+    local -a args=(clone --quiet "https://github.com/${slug}.git" "${dest}")
+    if [ "${DEPTH}" -gt 0 ]; then
+      args+=(--depth="${DEPTH}" --single-branch --no-tags)
+    fi
+
+    outcome="FAIL  ${slug}"
+    local attempt
+    for attempt in $(seq 1 "${RETRIES}"); do
+      if git "${args[@]}" 2>/dev/null; then
+        outcome="OK    ${slug}"
+        break
+      fi
+      rm -rf "${dest}"
+      sleep $(( attempt * attempt * 2 ))
+    done
+  fi
+
+  printf '%s\n' "${outcome}" >> "${CLONE_LOG}"
+}
+export -f clone_one
+export OUTPUT DEPTH RETRIES CLONE_LOG
+
+# Progress bar matching main.cpp's per-language renderer: 40-wide "[####....]"
+# refreshed in place. A background watcher polls the clone log every 200 ms
+# and re-renders, so all stdio races stay inside this one process.
+draw_bar() {
+  local n=$1 tot=$2
+  local pct=$(( tot > 0 ? n * 100 / tot : 0 ))
+  local W=40
+  local filled=$(( pct * W / 100 ))
+  local full='########################################'
+  local empty='........................................'
+  printf '\r  [%s%s] %d/%d (%d%%)   ' \
+    "${full:0:filled}" "${empty:0:$((W - filled))}" "$n" "$tot" "$pct" >&2
+}
+export -f draw_bar
+
+(
+  while :; do
+    sleep 0.2
+    if [ -f "${CLONE_LOG}" ]; then
+      n=$(wc -l < "${CLONE_LOG}" 2>/dev/null | tr -d ' ')
+      [ -z "$n" ] && n=0
+      [ "$n" -gt "${total}" ] && n=${total}
+      draw_bar "$n" "${total}"
+    fi
+  done
+) &
+WATCHER_PID=$!
+# Make sure the watcher dies even if we exit via an error.
+trap 'rm -f "${ALL_REPOS}"; kill "${WATCHER_PID}" 2>/dev/null; wait "${WATCHER_PID}" 2>/dev/null || true' EXIT
+
+# Fan out one slug per worker, bounded by JOBS. The `bash -c '… "$@"' _`
+# pattern is the portable way to invoke an exported function via xargs.
+< "${ALL_REPOS}" xargs -n1 -P "${JOBS}" bash -c 'clone_one "$@"' _
+
+# Stop the watcher and paint the final state.
+kill "${WATCHER_PID}" 2>/dev/null
+wait "${WATCHER_PID}" 2>/dev/null || true
+
+ok=$(grep -c '^OK   ' "${CLONE_LOG}" || true)
+sk=$(grep -c '^SKIP ' "${CLONE_LOG}" || true)
+ko=$(grep -c '^FAIL ' "${CLONE_LOG}" || true)
+finished=$(( ok + sk + ko ))
+draw_bar "${finished}" "${total}"
+printf '\n' >&2
+
+log ""
+log "done: ${ok} cloned, ${sk} skipped, ${ko} failed (of ${total})"
+if [ "${ko}" -gt 0 ]; then
+  log "failed repos (also in ${CLONE_LOG}):"
+  grep '^FAIL ' "${CLONE_LOG}" | sed 's/^FAIL  /  /' >&2
+fi
+[ "${ko}" -eq 0 ]

--- a/LLVM/include/EmbeddedStats.hpp
+++ b/LLVM/include/EmbeddedStats.hpp
@@ -37,7 +37,7 @@
   X(toothpicksConvertedAvg, "Average Toothpicks (Converted)", "Average toothpick count per sample after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
   X(toothpicksConvertedAvgWith, "Average With Toothpicks (Converted)", "Average toothpick count among samples that still contain toothpicks after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
   X(toothpicksReductionTotal, "Toothpick Reduction Total (%)", "Percentage reduction in total toothpicks after rewriting matchertext-compliant string literals as C++ raw string literals.") \
-  X(toothpicksReductionAvg, "Toothpick Reduction Average (%)", "Percentage reduction in average per-sample toothpicks after rewriting matchertext-compliant string literals as C++ raw string literals.") \
+  X(toothpicksReductionAvg, "Toothpick Reduction Average (%)", "Mean of each sample's own percentage reduction in toothpicks after rewriting matchertext-compliant string literals as C++ raw string literals (samples without toothpicks count as 0%).") \
   X(toothpicksReductionMax, "Toothpick Reduction Maximum (%)", "Percentage reduction in the maximum per-sample toothpick count after rewriting matchertext-compliant string literals as C++ raw string literals.") \
   \
   X(withNesting, "With Raw Nested Embedding", "Number of samples whose raw nesting depth exceeds 1, even if the nesting is never closed.") \
@@ -55,7 +55,10 @@
   AtomicString stringMaxToothpicks; \
   AtomicString stringMaxNonCompliance; \
   AtomicString stringMaxNested; \
-  AtomicString stringMaxValidNested;
+  AtomicString stringMaxValidNested; \
+  /* Running sum of per-sample toothpick reduction percentages; consumed by */ \
+  /* DeriveStats to compute toothpicksReductionAvg. Not an output column. */ \
+  std::atomic<double> toothpicksReductionSum{0};
 
 CREATE_STATS_HPP(EmbeddedStats, EMBEDDED_STATS_FIELDS, EMBEDDED_EXTRA_FIELDS
 )

--- a/LLVM/include/EmbeddedStats.hpp
+++ b/LLVM/include/EmbeddedStats.hpp
@@ -30,6 +30,16 @@
   X(nonComplianceAvg, "Avg Unmatched Matchers Per Sample", "Average non-compliance count per sample.") \
   X(complianceRate, "Compliance Rate", "Percentage of samples without non-compliance.") \
   \
+  X(compliantCount, "Compliant Samples", "Number of samples with no matchertext non-compliance (count minus With Non-Compliance).") \
+  X(withToothpicksConverted, "With Toothpicks (Converted)", "Number of samples still containing at least one toothpick after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
+  X(toothpicksConverted, "Total Toothpicks (Converted)", "Total toothpick count after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
+  X(toothpicksConvertedMax, "Maximum Toothpicks (Converted)", "Highest toothpick count in a single sample after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
+  X(toothpicksConvertedAvg, "Average Toothpicks (Converted)", "Average toothpick count per sample after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
+  X(toothpicksConvertedAvgWith, "Average With Toothpicks (Converted)", "Average toothpick count among samples that still contain toothpicks after rewriting each matchertext-compliant string literal as an equivalent C++ raw string literal.") \
+  X(toothpicksReductionTotal, "Toothpick Reduction Total (%)", "Percentage reduction in total toothpicks after rewriting matchertext-compliant string literals as C++ raw string literals.") \
+  X(toothpicksReductionAvg, "Toothpick Reduction Average (%)", "Percentage reduction in average per-sample toothpicks after rewriting matchertext-compliant string literals as C++ raw string literals.") \
+  X(toothpicksReductionMax, "Toothpick Reduction Maximum (%)", "Percentage reduction in the maximum per-sample toothpick count after rewriting matchertext-compliant string literals as C++ raw string literals.") \
+  \
   X(withNesting, "With Raw Nested Embedding", "Number of samples whose raw nesting depth exceeds 1, even if the nesting is never closed.") \
   X(nestingDepthTotal, "Sum Of Per-Sample Raw Max Depth", "Sum of each sample's maximum raw nesting depth, counting unmatched openers such as '((('.") \
   X(nestingDepthMax, "Highest Per-Sample Raw Max Depth", "Greatest raw nesting depth observed in any single sample, even if the nesting is left open.") \

--- a/LLVM/include/Parser.hpp
+++ b/LLVM/include/Parser.hpp
@@ -101,7 +101,7 @@ class Parser final {
       LanguageStats *langStats = nullptr, bool relaxed = false,
       std::string_view sourcePath = {}, std::string_view inputPath = {},
       EmbeddedStats *extraEmbedded = nullptr, NestedStats *extraNested = nullptr,
-      LanguageStats *extraLangStats = nullptr
+      LanguageStats *extraLangStats = nullptr, uint64_t convertedToothpicksHint = 0
     );
 };
 

--- a/LLVM/include/Parser.hpp
+++ b/LLVM/include/Parser.hpp
@@ -91,6 +91,8 @@ class Parser final {
     inline static FileStats FILE_STATS{};
     /// Per-language classification statistics for strings
     inline static LanguageStats STRING_LANG_STATS{};
+
+    static uint64_t CountRawStringToothpicks(std::string_view body);
   private:
     /// Processes a string/doc and updates the given stat
     /// @returns the number of MatcherText violations found

--- a/LLVM/makefile
+++ b/LLVM/makefile
@@ -16,5 +16,5 @@ build:
 
 test:
 	@cmake -B $(TEST_BUILD_DIR) -S .
-	@cmake --build $(TEST_BUILD_DIR) --target LanguageClassifierTests ParserFixtureTests DebugLanguageOutputTests
+	@cmake --build $(TEST_BUILD_DIR) --target LanguageClassifierTests ParserFixtureTests DebugLanguageOutputTests StringLiteralDecodeTests
 	@ctest --test-dir $(TEST_BUILD_DIR) --output-on-failure

--- a/LLVM/src/EmbeddedStats.cpp
+++ b/LLVM/src/EmbeddedStats.cpp
@@ -23,4 +23,21 @@ void EmbeddedStats::DeriveStats() {
   complianceRate.store(100.0 * (n > 0.0 ? (n - wnc) / n : 0.0), std::memory_order_relaxed);
   nestingDepthAvg.store(n > 0.0 ? nd / n : 0.0, std::memory_order_relaxed);
   validNestingDepthAvg.store(n > 0.0 ? vnd / n : 0.0, std::memory_order_relaxed);
+
+  // Stats after rewriting every matchertext-compliant string literal as an
+  // equivalent C++ raw string literal (non-compliant strings and comments are
+  // counted unchanged, so for non-string sources the reductions come out as 0).
+  const double tpc = toothpicksConverted.load(std::memory_order_relaxed);
+  const double wnc2 = withToothpicksConverted.load(std::memory_order_relaxed);
+  const double tpcMax = toothpicksConvertedMax.load(std::memory_order_relaxed);
+  const double tpcAvg = n > 0.0 ? tpc / n : 0.0;
+  const double tpAvg = n > 0.0 ? tp / n : 0.0;
+  const double tpMax = toothpicksMax.load(std::memory_order_relaxed);
+
+  compliantCount.store(n - wnc, std::memory_order_relaxed);
+  toothpicksConvertedAvg.store(tpcAvg, std::memory_order_relaxed);
+  toothpicksConvertedAvgWith.store(wnc2 > 0.0 ? tpc / wnc2 : 0.0, std::memory_order_relaxed);
+  toothpicksReductionTotal.store(tp > 0.0 ? 100.0 * (tp - tpc) / tp : 0.0, std::memory_order_relaxed);
+  toothpicksReductionAvg.store(tpAvg > 0.0 ? 100.0 * (tpAvg - tpcAvg) / tpAvg : 0.0, std::memory_order_relaxed);
+  toothpicksReductionMax.store(tpMax > 0.0 ? 100.0 * (tpMax - tpcMax) / tpMax : 0.0, std::memory_order_relaxed);
 }

--- a/LLVM/src/EmbeddedStats.cpp
+++ b/LLVM/src/EmbeddedStats.cpp
@@ -31,13 +31,16 @@ void EmbeddedStats::DeriveStats() {
   const double wnc2 = withToothpicksConverted.load(std::memory_order_relaxed);
   const double tpcMax = toothpicksConvertedMax.load(std::memory_order_relaxed);
   const double tpcAvg = n > 0.0 ? tpc / n : 0.0;
-  const double tpAvg = n > 0.0 ? tp / n : 0.0;
   const double tpMax = toothpicksMax.load(std::memory_order_relaxed);
+  const double trs = toothpicksReductionSum.load(std::memory_order_relaxed);
 
   compliantCount.store(n - wnc, std::memory_order_relaxed);
   toothpicksConvertedAvg.store(tpcAvg, std::memory_order_relaxed);
   toothpicksConvertedAvgWith.store(wnc2 > 0.0 ? tpc / wnc2 : 0.0, std::memory_order_relaxed);
   toothpicksReductionTotal.store(tp > 0.0 ? 100.0 * (tp - tpc) / tp : 0.0, std::memory_order_relaxed);
-  toothpicksReductionAvg.store(tpAvg > 0.0 ? 100.0 * (tpAvg - tpcAvg) / tpAvg : 0.0, std::memory_order_relaxed);
+  // Mean of per-sample reductions. Aggregating per-sample percentages this way is
+  // genuinely distinct from the aggregate total: (tp-tpc)/tp weights each sample by
+  // its toothpick count, whereas this weights every sample equally.
+  toothpicksReductionAvg.store(n > 0.0 ? trs / n : 0.0, std::memory_order_relaxed);
   toothpicksReductionMax.store(tpMax > 0.0 ? 100.0 * (tpMax - tpcMax) / tpMax : 0.0, std::memory_order_relaxed);
 }

--- a/LLVM/src/Parser.cpp
+++ b/LLVM/src/Parser.cpp
@@ -267,12 +267,16 @@ static std::string ExtractLiteralBody(std::string_view spelling) {
 }
 
 // Counts the backslash bytes that would remain if a C/C++ string literal body were
-// rewritten verbatim inside a raw string literal R"(...)" — i.e. the backslashes in
-// the decoded content. Escape-introducing backslashes (\n, \t, \", \\, ...) collapse
-// away; only genuine content backslashes survive. Best effort: assumes `body` comes
-// from a normal (non-raw) literal, where every '\' starts an escape sequence; bodies
-// taken from raw literals (or normal+raw concatenations) are over-collapsed.
-static uint64_t CountRawStringToothpicks(const std::string_view body) {
+// rewritten verbatim inside a raw string literal R"(...)" — i.e. the number of '\'
+// characters in the *decoded* content. Escape sequences are decoded semantically:
+// only sequences that actually produce a 0x5C code unit are counted (\\, octal \ooo,
+// hex \xH..., the \uXXXX / \UXXXXXXXX universal-character-name forms, and the C++23
+// delimited forms \x{...} / \o{...} / \u{...} / \N{REVERSE SOLIDUS}). `body` is
+// expected to already have line splices removed
+// (clang::Lexer::getSpelling does this); bodies taken from raw literals — or from
+// normal+raw adjacent-literal concatenations — are decoded as if normal and may be
+// over-collapsed, which is an accepted approximation here.
+uint64_t Parser::CountRawStringToothpicks(std::string_view body) {
   const auto hexDigit = [](const unsigned char c) -> int {
     if (c >= '0' && c <= '9')
       return c - '0';
@@ -282,51 +286,140 @@ static uint64_t CountRawStringToothpicks(const std::string_view body) {
       return c - 'A' + 10;
     return -1;
   };
+  const auto octDigit = [](const unsigned char c) -> int {
+    return c >= '0' && c <= '7' ? c - '0' : -1;
+  };
+
+  const size_t n = body.size();
+
+  // Reads exactly `digits` hex digits starting at body[i]; advances i past them on success.
+  const auto parseFixedHex = [&](size_t &i, const int digits, uint32_t &value) -> bool {
+    value = 0;
+    for (int k = 0; k < digits; ++k) {
+      if (i >= n)
+        return false;
+      const int d = hexDigit(static_cast<unsigned char>(body[i]));
+      if (d < 0)
+        return false;
+      value = value * 16u + static_cast<uint32_t>(d);
+      ++i;
+    }
+    return true;
+  };
+
+  // Reads a "{ digits }" run in the given base starting at body[i]; advances i past the
+  // closing brace on success. Requires at least one digit.
+  const auto parseBracedNumber = [&](size_t &i, const int base, uint32_t &value) -> bool {
+    if (i >= n || body[i] != '{')
+      return false;
+    ++i;
+
+    value = 0;
+    bool any = false;
+    while (i < n && body[i] != '}') {
+      const int d = base == 16
+                      ? hexDigit(static_cast<unsigned char>(body[i]))
+                      : octDigit(static_cast<unsigned char>(body[i]));
+      if (d < 0)
+        return false;
+      value = value * static_cast<uint32_t>(base) + static_cast<uint32_t>(d);
+      any = true;
+      ++i;
+    }
+    if (i >= n || body[i] != '}')
+      return false;
+    ++i;
+    return any;
+  };
 
   uint64_t count = 0;
-  const size_t n = body.size();
   for (size_t i = 0; i < n;) {
-    if (static_cast<unsigned char>(body[i]) != '\\') {
+    if (body[i] != '\\') {
       ++i;
       continue;
     }
 
-    // Start of an escape sequence; the leading backslash itself collapses away.
+    // Start of an escape sequence; the leading backslash itself does not survive.
     if (++i >= n)
       break; // dangling backslash — not valid source, ignore.
 
-    if (const auto e = static_cast<unsigned char>(body[i]); e == '\\') {
-      // \\ -> one literal backslash survives.
+    const auto e = static_cast<unsigned char>(body[i]);
+
+    if (e == '\\') { // \\ -> one literal backslash survives
       ++count;
       ++i;
-    } else if (e == 'x') {
-      // \xH... hex escape, greedy over hex digits.
-      ++i;
-      unsigned long value = 0;
-      bool any = false;
-      for (int d = 0; i < n && (d = hexDigit(static_cast<unsigned char>(body[i]))) >= 0; ++i) {
-        value = value * 16 + static_cast<unsigned long>(d);
-        any = true;
-      }
-      if (any && (value & 0xFFul) == 0x5Cul)
-        ++count;
-    } else if (e == 'u' || e == 'U') {
-      // \uHHHH / \UHHHHHHHH universal character name — never a bare backslash in valid source.
-      const int digits = e == 'u' ? 4 : 8;
-      ++i;
-      for (int d = 0; d < digits && i < n && hexDigit(static_cast<unsigned char>(body[i])) >= 0; ++d)
-        ++i;
-    } else if (e >= '0' && e <= '7') {
-      // \ooo octal escape, up to 3 digits.
-      unsigned value = 0;
-      for (int d = 0; d < 3 && i < n && body[i] >= '0' && body[i] <= '7'; ++d, ++i)
-        value = value * 8 + static_cast<unsigned>(body[i] - '0');
-      if ((value & 0xFFu) == 0x5Cu)
-        ++count;
-    } else {
-      // Simple escape (\n \t \r \v \f \a \b \" \' \? ...): the escaped char is not a backslash.
-      ++i;
+      continue;
     }
+
+    if (e == 'x') { // \xH... or (C++23) \x{ H... }
+      ++i;
+      uint32_t value = 0;
+      if (i < n && body[i] == '{') {
+        if (parseBracedNumber(i, 16, value) && value == 0x5Cu)
+          ++count;
+        continue;
+      }
+      bool any = false;
+      while (i < n) {
+        const int d = hexDigit(static_cast<unsigned char>(body[i]));
+        if (d < 0)
+          break;
+        value = value * 16u + static_cast<uint32_t>(d);
+        any = true;
+        ++i;
+      }
+      if (any && value == 0x5Cu)
+        ++count;
+      continue;
+    }
+
+    if (e == 'o') { // (C++23) \o{ O... }
+      ++i;
+      uint32_t value = 0;
+      if (i < n && body[i] == '{' && parseBracedNumber(i, 8, value) && value == 0x5Cu)
+        ++count;
+      continue;
+    }
+
+    if (e == 'u' || e == 'U') { // \uHHHH, \UHHHHHHHH, or (C++23) \u{ H... }
+      ++i;
+      uint32_t value = 0;
+      if (i < n && body[i] == '{') {
+        if (parseBracedNumber(i, 16, value) && value == 0x5Cu)
+          ++count;
+        continue;
+      }
+      if (parseFixedHex(i, e == 'u' ? 4 : 8, value) && value == 0x5Cu)
+        ++count;
+      continue;
+    }
+
+    if (e == 'N') { // (C++23) named universal character escape \N{ NAME }
+      ++i;
+      constexpr std::string_view reverseSolidus = "{REVERSE SOLIDUS}";
+      if (body.substr(i, reverseSolidus.size()) == reverseSolidus) {
+        ++count;
+        i += reverseSolidus.size();
+      }
+      continue;
+    }
+
+    if (e >= '0' && e <= '7') { // \ooo octal escape, up to 3 digits
+      uint32_t value = 0;
+      for (int d = 0; d < 3 && i < n; ++d) {
+        const int od = octDigit(static_cast<unsigned char>(body[i]));
+        if (od < 0)
+          break;
+        value = value * 8u + static_cast<uint32_t>(od);
+        ++i;
+      }
+      if (value == 0x5Cu)
+        ++count;
+      continue;
+    }
+
+    // Simple escapes (\n \t \r \v \f \a \b \" \' \? ...): none decodes to a backslash.
+    ++i;
   }
   return count;
 }

--- a/LLVM/src/Parser.cpp
+++ b/LLVM/src/Parser.cpp
@@ -266,6 +266,71 @@ static std::string ExtractLiteralBody(std::string_view spelling) {
   return std::string(spelling.substr(open + 1, close - open - 1));
 }
 
+// Counts the backslash bytes that would remain if a C/C++ string literal body were
+// rewritten verbatim inside a raw string literal R"(...)" — i.e. the backslashes in
+// the decoded content. Escape-introducing backslashes (\n, \t, \", \\, ...) collapse
+// away; only genuine content backslashes survive. Best effort: assumes `body` comes
+// from a normal (non-raw) literal, where every '\' starts an escape sequence; bodies
+// taken from raw literals (or normal+raw concatenations) are over-collapsed.
+static uint64_t CountRawStringToothpicks(const std::string_view body) {
+  const auto hexDigit = [](const unsigned char c) -> int {
+    if (c >= '0' && c <= '9')
+      return c - '0';
+    if (c >= 'a' && c <= 'f')
+      return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+      return c - 'A' + 10;
+    return -1;
+  };
+
+  uint64_t count = 0;
+  const size_t n = body.size();
+  for (size_t i = 0; i < n;) {
+    if (static_cast<unsigned char>(body[i]) != '\\') {
+      ++i;
+      continue;
+    }
+
+    // Start of an escape sequence; the leading backslash itself collapses away.
+    if (++i >= n)
+      break; // dangling backslash — not valid source, ignore.
+
+    if (const auto e = static_cast<unsigned char>(body[i]); e == '\\') {
+      // \\ -> one literal backslash survives.
+      ++count;
+      ++i;
+    } else if (e == 'x') {
+      // \xH... hex escape, greedy over hex digits.
+      ++i;
+      unsigned long value = 0;
+      bool any = false;
+      for (int d = 0; i < n && (d = hexDigit(static_cast<unsigned char>(body[i]))) >= 0; ++i) {
+        value = value * 16 + static_cast<unsigned long>(d);
+        any = true;
+      }
+      if (any && (value & 0xFFul) == 0x5Cul)
+        ++count;
+    } else if (e == 'u' || e == 'U') {
+      // \uHHHH / \UHHHHHHHH universal character name — never a bare backslash in valid source.
+      const int digits = e == 'u' ? 4 : 8;
+      ++i;
+      for (int d = 0; d < digits && i < n && hexDigit(static_cast<unsigned char>(body[i])) >= 0; ++d)
+        ++i;
+    } else if (e >= '0' && e <= '7') {
+      // \ooo octal escape, up to 3 digits.
+      unsigned value = 0;
+      for (int d = 0; d < 3 && i < n && body[i] >= '0' && body[i] <= '7'; ++d, ++i)
+        value = value * 8 + static_cast<unsigned>(body[i] - '0');
+      if ((value & 0xFFu) == 0x5Cu)
+        ++count;
+    } else {
+      // Simple escape (\n \t \r \v \f \a \b \" \' \? ...): the escaped char is not a backslash.
+      ++i;
+    }
+  }
+  return count;
+}
+
 void Parser::ParseFile(const std::string &filePath, const std::string &inputPath) {
   if (Serde::JSON result; ParseC_CPP(filePath, result) && result.IsArray())
     GatherStatistics(std::move(result), filePath, inputPath);
@@ -420,6 +485,14 @@ uint64_t Parser::process(
 
   const auto [unmatched, maxDepth, maxValidDepth, rawChars] = AnalyzeMatcherText(string, relaxed);
 
+  /// Toothpick count after rewriting this sample under the matchertext rule: a
+  /// matchertext-compliant string literal is replaced by an equivalent C++ raw
+  /// string literal (langStats is non-null only for string literals); everything
+  /// else (non-compliant strings, comments) is counted unchanged.
+  const bool compliantStringLiteral = langStats != nullptr && unmatched == 0;
+  const uint64_t convertedToothpicks =
+      compliantStringLiteral ? CountRawStringToothpicks(string) : toothpicks;
+
   if (langStats != nullptr) {
     /// Classify the embedded language and record per-language stats only for strings.
     if (const auto [lang, confidence] = ClassifyString(string); lang != LanguageEnum::Unknown) {
@@ -446,6 +519,11 @@ uint64_t Parser::process(
     AtomicAdd(s.toothpicks, static_cast<double>(toothpicks));
     if (AtomicMax(s.toothpicksMax, static_cast<double>(toothpicks)))
       s.stringMaxToothpicks.set(string);
+
+    if (convertedToothpicks > 0)
+      AtomicAdd(s.withToothpicksConverted, 1.0);
+    AtomicAdd(s.toothpicksConverted, static_cast<double>(convertedToothpicks));
+    AtomicMax(s.toothpicksConvertedMax, static_cast<double>(convertedToothpicks));
 
     if (unmatched > 0)
       AtomicAdd(s.withNonCompliance, 1.0);

--- a/LLVM/src/Parser.cpp
+++ b/LLVM/src/Parser.cpp
@@ -4,6 +4,7 @@
 // Date: 13/06/2025
 //
 
+#include <algorithm>
 #include <array>
 #include <filesystem>
 #include <fstream>
@@ -240,18 +241,22 @@ static bool IsStringToken(const clang::Token &tok) {
 // Returns the source-form body of one string token.
 // Normal strings keep escapes as written.
 // Raw strings return verbatim raw body.
-static std::string ExtractLiteralBody(std::string_view spelling) {
+// `isRaw` is set to true iff the token is a raw string literal (R"delim(...)delim");
+// this lets callers count toothpicks per-segment without re-decoding raw bodies.
+static std::string ExtractLiteralBody(std::string_view spelling, bool &isRaw) {
+  isRaw = false;
   const size_t quote = spelling.find('"');
   if (quote == std::string_view::npos)
     return {};
 
-  if (const bool isRaw = quote > 0 && spelling[quote - 1] == 'R'; !isRaw) {
+  if (const bool raw = quote > 0 && spelling[quote - 1] == 'R'; !raw) {
     const size_t end = spelling.rfind('"');
     if (end == std::string_view::npos || end <= quote)
       return {};
     return std::string(spelling.substr(quote + 1, end - quote - 1));
   }
 
+  isRaw = true;
   // Raw form: prefix R"delim(body)delim"
   const size_t open = spelling.find('(', quote);
   if (open == std::string_view::npos)
@@ -491,17 +496,34 @@ bool Parser::ParseC_CPP(const std::string &path, Serde::JSON &result) {
     /// Handle string literal tokens.
     if (IsStringToken(tok)) {
       std::string value;
+      uint64_t convertedToothpicks = 0;
       clang::Token current = tok;
 
       /// Concatenate adjacent string literals ("a" "b").
       do {
         const std::string spelling = clang::Lexer::getSpelling(current, srcMgr, langOpts);
-        value += ExtractLiteralBody(spelling);
+        bool isRaw = false;
+        std::string body = ExtractLiteralBody(spelling, isRaw);
+
+        /// Toothpicks that survive rewriting this segment as a raw string literal,
+        /// counted per-segment so adjacent normal+raw literals are each handled in
+        /// their own mode. A raw literal is already raw, so its backslashes are
+        /// literal and kept verbatim; a normal literal's escapes decode down to the
+        /// backslashes their content actually holds.
+        convertedToothpicks += isRaw
+          ? static_cast<uint64_t>(std::count(body.begin(), body.end(), '\\'))
+          : CountRawStringToothpicks(body);
+
+        value += body;
         lexer.LexFromRawLexer(current);
       } while (IsStringToken(current));
 
       tok = current;
-      result.PushBack(Serde::JSON::Object({{"kind", Serde::JSON("string")}, {"value", Serde::JSON(value)}}));
+      result.PushBack(Serde::JSON::Object({
+        {"kind", Serde::JSON("string")},
+        {"value", Serde::JSON(value)},
+        {"convertedToothpicks", Serde::JSON(static_cast<double>(convertedToothpicks))}
+      }));
       continue;
     }
 
@@ -524,12 +546,16 @@ void Parser::GatherStatistics(
   for (auto e: json.GetArray()) {
     std::string value = e["value"].GetString();
     if (e["kind"].GetString() == "string") {
+      const uint64_t convertedToothpicks = e.Contains("convertedToothpicks")
+        ? static_cast<uint64_t>(e["convertedToothpicks"].GetNumber())
+        : 0;
       const uint64_t violations = process(
         std::move(value), STRING_STATS, STRING_NESTED_STATS, &STRING_LANG_STATS, false, path,
         inputPath.empty() ? std::string_view(path) : inputPath,
         perLang ? &perLang->stringStats : nullptr,
         perLang ? &perLang->stringNestedStats : nullptr,
-        perLang ? &perLang->langStats : nullptr
+        perLang ? &perLang->langStats : nullptr,
+        convertedToothpicks
       );
       fileViolations += violations;
       fileViolationsRelaxed += violations;
@@ -568,7 +594,8 @@ uint64_t Parser::process(
   std::string &&string, EmbeddedStats &stats, NestedStats &nestedStats,
   LanguageStats *langStats, const bool relaxed,
   const std::string_view sourcePath, const std::string_view inputPath,
-  EmbeddedStats *extraEmbedded, NestedStats *extraNested, LanguageStats *extraLangStats
+  EmbeddedStats *extraEmbedded, NestedStats *extraNested, LanguageStats *extraLangStats,
+  const uint64_t convertedToothpicksHint
 ) {
   uint64_t toothpicks = 0;
   for (const unsigned char c: string) {
@@ -581,10 +608,13 @@ uint64_t Parser::process(
   /// Toothpick count after rewriting this sample under the matchertext rule: a
   /// matchertext-compliant string literal is replaced by an equivalent C++ raw
   /// string literal (langStats is non-null only for string literals); everything
-  /// else (non-compliant strings, comments) is counted unchanged.
+  /// else (non-compliant strings, comments) is counted unchanged. The converted
+  /// count for compliant literals is computed per-segment at extraction time
+  /// (convertedToothpicksHint) so raw and adjacent normal+raw literals are each
+  /// counted in their own mode rather than re-decoding the concatenated body.
   const bool compliantStringLiteral = langStats != nullptr && unmatched == 0;
   const uint64_t convertedToothpicks =
-      compliantStringLiteral ? CountRawStringToothpicks(string) : toothpicks;
+      compliantStringLiteral ? convertedToothpicksHint : toothpicks;
 
   if (langStats != nullptr) {
     /// Classify the embedded language and record per-language stats only for strings.
@@ -617,6 +647,15 @@ uint64_t Parser::process(
       AtomicAdd(s.withToothpicksConverted, 1.0);
     AtomicAdd(s.toothpicksConverted, static_cast<double>(convertedToothpicks));
     AtomicMax(s.toothpicksConvertedMax, static_cast<double>(convertedToothpicks));
+
+    /// Per-sample reduction (%), accumulated so DeriveStats can report the mean
+    /// of per-sample reductions rather than a value algebraically identical to
+    /// the aggregate total. Samples with no toothpicks contribute 0%.
+    if (toothpicks > 0)
+      AtomicAdd(
+        s.toothpicksReductionSum,
+        100.0 * static_cast<double>(toothpicks - convertedToothpicks) / static_cast<double>(toothpicks)
+      );
 
     if (unmatched > 0)
       AtomicAdd(s.withNonCompliance, 1.0);

--- a/LLVM/tests/parser_fixture_test.cpp
+++ b/LLVM/tests/parser_fixture_test.cpp
@@ -86,6 +86,19 @@ bool TestRawAndAdjacent() {
   ok &= CheckEq("raw.strings.with_toothpicks", strings.withToothpicks, 2.0);
   ok &= CheckEq("raw.strings.toothpicks", strings.toothpicks, 10.0);
   ok &= CheckEq("raw.strings.raw_chars", strings.rawChars, 94.0);
+
+  // Converted-form toothpicks. kRegex is a raw literal whose body holds 4 literal
+  // backslashes (\[ \] \( \)); converting an already-raw literal keeps all 4, so it
+  // must not be re-decoded down to 0. kJson's "\"" escapes (6 toothpicks) collapse to
+  // 0, and kSql has none — total converted = 4, all from the single raw kRegex sample.
+  ok &= CheckEq("raw.strings.toothpicks_converted", strings.toothpicksConverted, 4.0);
+  ok &= CheckEq("raw.strings.with_toothpicks_converted", strings.withToothpicksConverted, 1.0);
+  ok &= CheckEq("raw.strings.toothpicks_converted_max", strings.toothpicksConvertedMax, 4.0);
+  // Total reduction weights by toothpick count: (10-4)/10 = 60%. The per-sample mean
+  // weights each sample equally: (0% for kSql, 100% for kJson, 0% for kRegex)/3 ≈ 33.3%.
+  // The two metrics are now genuinely distinct.
+  ok &= CheckEq("raw.strings.reduction_total", strings.toothpicksReductionTotal, 60.0);
+  ok &= CheckEq("raw.strings.reduction_avg", strings.toothpicksReductionAvg, 100.0 / 3.0);
   ok &= CheckEq("raw.docs.count", docs.count, 1.0);
   ok &= CheckEq("raw.lang.total", static_cast<double>(lang.total), 3.0);
 

--- a/LLVM/tests/string_literal_decode_test.cpp
+++ b/LLVM/tests/string_literal_decode_test.cpp
@@ -1,0 +1,123 @@
+//
+// string_literal_decode_test.cpp
+// Author: Antoine Bastide
+// Date: 12.05.2026
+//
+// Unit tests for Parser::CountRawStringToothpicks — given the *body* of a C/C++
+// string literal (the text between the quotes, line splices already removed), it
+// returns how many backslash bytes the literal's decoded content holds, i.e. how
+// many toothpicks survive a rewrite to a raw string literal.
+//
+// Test inputs are written as raw string literals R"(...)" so the test's own
+// compiler does not pre-decode the escape sequences being exercised. The bare
+// four-hex-digit "\uXXXX" universal-character-name form is assembled at runtime
+// (a backslash string + the rest), because writing it literally here is risky.
+//
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "Parser.hpp"
+
+namespace {
+int failures = 0;
+int checks = 0;
+
+void Expect(const std::string_view label, const std::string_view body, const uint64_t expected) {
+  ++checks;
+  const uint64_t actual = Parser::CountRawStringToothpicks(body);
+  if (actual == expected)
+    return;
+  ++failures;
+  std::cerr << "string_literal_decode_test FAILED: " << label
+            << " | body=<" << body << "> expected=" << expected
+            << " actual=" << actual << '\n';
+}
+
+const std::string kBackslash = "\\"; // a single backslash, used to build "\uXXXX" inputs
+} // namespace
+
+int main() {
+  // --- Happy path: a single escape sequence that decodes to one backslash (0x5C) ---
+  Expect("escaped backslash", R"(\\)", 1);
+  Expect("octal escape 134", R"(\134)", 1);
+  Expect("hex escape x5c (lower)", R"(\x5c)", 1);
+  Expect("hex escape x5C (upper digit)", R"(\x5C)", 1);
+  Expect("hex escape x05c (leading zero, == 0x5c)", R"(\x05c)", 1);
+  Expect("UCN backslash-u 005c (lower u)", kBackslash + "u005c", 1);
+  Expect("UCN backslash-u 005C (lower u, upper hex)", kBackslash + "u005C", 1);
+  Expect("UCN backslash-U 0000005c (upper U)", R"(\U0000005c)", 1);
+  Expect("C++23 delimited hex x{5c}", R"(\x{5c})", 1);
+  Expect("C++23 delimited hex x{5C}", R"(\x{5C})", 1);
+  Expect("C++23 delimited hex x{00005c}", R"(\x{00005c})", 1);
+  Expect("C++23 delimited octal o{134}", R"(\o{134})", 1);
+  Expect("C++23 delimited UCN u{5c}", R"(\u{5c})", 1);
+  Expect("C++23 delimited UCN u{0000005c}", R"(\u{0000005c})", 1);
+  Expect("C++23 named UCN N{REVERSE SOLIDUS}", R"(\N{REVERSE SOLIDUS})", 1);
+
+  // --- Happy path: counting multiple / mixed sequences ---
+  Expect("two escaped backslashes", R"(\\\\)", 2);
+  Expect("escaped backslash then literal n", R"(\\n)", 1);                  // decoded: '\' 'n'
+  Expect("windows-style path", R"(C:\\dir\\sub\\file)", 3);
+  Expect("mix of escaped backslash, n, octal, hex", R"(a\\b\nc\134d\x5c)", 3); // \\, \134, \x5c => 3 ; \n => 0
+  Expect("one of each non-bare backslash-producing escape form",
+         R"(\\\134\x5c\U0000005c\x{5c}\o{134}\u{5c}\N{REVERSE SOLIDUS})", 8);
+  Expect("backslash buried in plain text", R"(prefix \\ suffix)", 1);
+  Expect("three octal backslashes", R"(\134\134\134)", 3);
+
+  // --- Sad path: escapes that do NOT decode to a backslash ---
+  Expect("plain text, no escapes", R"(plain text, no escapes here)", 0);
+  Expect("empty body", R"()", 0);
+  Expect("simple escapes only", R"(\n\t\r\v\f\a\b)", 0);
+  Expect("escaped quote / apostrophe / question mark", R"(\n\t\"\'\?)", 0);
+  Expect("hex escape x41 ('A')", R"(\x41)", 0);
+  Expect("hex x15c is 0x15C, not 0x5C (no low-byte truncation)", R"(\x15c)", 0);
+  Expect("greedy hex eats trailing hex: x5cc is 0x5CC", R"(\x5cc)", 0);
+  Expect("greedy hex eats trailing hex: x5ce is 0x5CE", R"(\x5ce)", 0);
+  Expect("octal 534 is 0o534 == 348, not 0x5C", R"(\534)", 0);
+  Expect("octal 0 then literal 'x5c'", R"(\0x5c)", 0);
+  Expect("octal 0 then literal '8' (8 is not an octal digit)", R"(\08)", 0);
+  Expect("octal limited to 3 digits: 01340 is 0o013 then '40'", R"(\01340)", 0);
+  Expect("UCN backslash-u 0041 ('A')", kBackslash + "u0041", 0);
+  Expect("UCN backslash-U 00000041 ('A')", R"(\U00000041)", 0);
+  Expect("C++23 braced hex x{41} ('A')", R"(\x{41})", 0);
+  Expect("C++23 braced octal o{101} (== 65, 'A')", R"(\o{101})", 0);
+  Expect("C++23 named UCN, different name", R"(\N{LATIN SMALL LETTER A})", 0);
+
+  // --- Weird / malformed inputs: best effort, must never over-count or crash ---
+  Expect("dangling backslash (whole body is one backslash)", R"x(\)x", 0);
+  Expect("text then dangling backslash", R"x(abc\)x", 0);
+  Expect("escaped backslash then literal '134' (not an octal escape)", R"(\\134)", 1);
+  Expect("escaped backslash then literal 'x5c' (not a hex escape)", R"(\\x5c)", 1);
+  Expect("backslash-x with no hex digits", R"(\xg)", 0);
+  Expect("backslash-x at end of body", R"(\x)", 0);
+  Expect("UCN backslash-u with too few hex digits", kBackslash + "u00", 0);
+  Expect("UCN backslash-u 005 (only 3 hex digits)", kBackslash + "u005", 0);
+  Expect("UCN backslash-U 0000005 (only 7 hex digits)", R"(\U0000005)", 0);
+  Expect("C++23 empty braces x{}", R"(\x{})", 0);
+  Expect("C++23 unterminated brace x{5c", R"(\x{5c)", 0);
+  Expect("C++23 unterminated brace o{134", R"(\o{134)", 0);
+  Expect("backslash-o without braces is not an escape", R"(\o134)", 0);
+  Expect("backslash-N without braces", R"(\Nfoo)", 0);
+  Expect("backslash-N{ name with surrounding spaces }", R"(\N{ REVERSE SOLIDUS })", 0);
+  Expect("backslash-N{REVERSE SOLIDUSX} (no exact closing brace)", R"(\N{REVERSE SOLIDUSX})", 0);
+  Expect("braces in plain text are harmless", R"(text { with } and { nested { braces } })", 0);
+  Expect("non-escape sequences mixed with braces", R"(\n {5c} \t)", 0);
+
+  // --- Documented over-collapse approximation (see Parser.hpp) ---
+  // CountRawStringToothpicks always decodes as if its input were a *normal* literal
+  // body. If the same characters had been the body of a *raw* literal R"(\\)" — true
+  // content two backslashes — the function still reports 1, not 2; and the body of
+  // R"(\n)" — true content '\' 'n' — is reported as 0, not 1.
+  Expect("raw-literal body two-backslashes over-collapses to 1", R"(\\)", 1);
+  Expect("raw-literal body backslash-n over-collapses to 0", R"(\n)", 0);
+
+  if (failures == 0) {
+    std::cout << "string_literal_decode_test: all " << checks << " checks passed.\n";
+    return 0;
+  }
+  std::cerr << "string_literal_decode_test: " << failures << " of " << checks << " checks failed.\n";
+  return 1;
+}


### PR DESCRIPTION
This PR adds a new set of statistics for converting MatcherText compliant strings to MatcherText literals. `Parser::CountRawStringToothpicks` is the main function that takes in a MatcherText compliant string and returns how many toothpicks can't be removed without breaking the string's semantics.

Globally this should that MatcherText removes about ~92% of toothpicks in strings.

The PR also contains the script to clone repos and parse them.