### PR TITLE
Injection-resistance paper draft

### DIFF
--- a/injection-research/doc/.gitignore
+++ b/injection-research/doc/.gitignore
@@ -1,0 +1,10 @@
+*.aux
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.toc
+*.out
+*.pdf
+*.md

--- a/injection-research/doc/Makefile
+++ b/injection-research/doc/Makefile
@@ -1,0 +1,31 @@
+.PHONY: FORCE lenny all clean distclean
+
+FILE=main
+BUILD=build
+
+all: $(FILE).pdf
+
+$(FILE).pdf: $(FILE).tex FORCE
+	latexmk -pdf -outdir=$(BUILD) $(FILE).tex
+	cp $(BUILD)/$(FILE).pdf $@
+
+fast:
+	mkdir -p $(BUILD)
+	pdflatex -output-directory=$(BUILD) $(FILE)
+	cp $(BUILD)/$(FILE).pdf $(FILE).pdf
+
+link:
+	rm -f *.bib
+	for lib in comp fault net os priv sec soc theory; do \
+		ln -s ../$$lib.bib $$lib.bib ; \
+	done
+
+clean:
+	$(RM) -r $(BUILD)
+	$(RM) *.aux *.bak *~
+
+distclean: clean
+	$(RM) $(FILE).pdf
+	$(RM) $(FILE).ps
+	$(RM) $(FILE).dvi
+	$(RM) *.d

--- a/injection-research/doc/abs.tex
+++ b/injection-research/doc/abs.tex
@@ -1,0 +1,24 @@
+\begin{abstract}
+Injection attacks remains one of the most persistent classes of software
+vulnerability, and the \emph{matchertext} discipline is being proposed as a
+structural defense: requiring the ASCII matcher pairs \verb|()|, \verb|[]|, and
+\verb|{}| to always match, so untrusted input in a matcher-delimited slot cannot
+break out without producing an unmatched matcher.
+This paper measures how much of the real injection landscape that proposal could
+structurally reach.
+We assemble a reproducible corpus unifying the MITRE CVE record with normalized
+enrichment and four proof-of-concept (PoC) databases, identify \textbf{91{,}760}
+injection CVEs among roughly 348k published records, and classify each by
+weakness family and by the embedded \emph{syntax} it targets.
+For the subset with an extractable PoC payload, we reduce each attack to a
+\emph{syntactic skeleton} and test whether a matchertext-aware host would contain
+it: whether the value sits in a matcher-delimited slot and is itself valid
+matchertext.
+We find that \textbf{82\%} of payload-backed injection CVEs are structurally
+contained, and, projected across all injection CVEs, at most \textbf{80\%} target
+a matcher-delimitable syntax; the residue is execution sinks and
+non-matcher-delimited contexts the discipline provably cannot address.
+These figures characterize the structure of recorded attack strings under a
+matchertext-aware host, not the behavior of a deployed defense: no such host is
+implemented or evaluated here.
+\end{abstract}

--- a/injection-research/doc/appendix.tex
+++ b/injection-research/doc/appendix.tex
@@ -1,0 +1,70 @@
+\section{Machine-checked Lean development}
+\label{sec:appendix:lean}
+
+The declaration heads below summarize the Lean~4 development in
+\texttt{injection-research/doc/proof.lean} that establishes premise~L1 of \cref{sec:threat} (there
+named \texttt{embed\_boundary}), extending the machine-checked closure
+development of~\cite{matchertext} with the boundary characterization that closure
+alone does not supply.
+Tactic proof bodies are elided here and given in full in the source file.
+
+\begin{lstlisting}
+import Mathlib
+open Classical
+
+variable {α : Type*}         -- the alphabet Σ, kept abstract
+variable (Pi : Set (α × α))  -- the set of pairs Π
+
+def Opener     (x : α) : Prop := ∃ y, (x, y) ∈ Pi
+def Closer     (x : α) : Prop := ∃ y, (y, x) ∈ Pi
+def Matcher    (x : α) : Prop := Opener Pi x ∨ Closer Pi x
+def Nonmatcher (x : α) : Prop := ¬ Matcher Pi x
+
+-- Lemma: no opener can be a closer, and vice versa.
+theorem disjoint
+    (h : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    (x : α) : ¬ (Opener Pi x ∧ Closer Pi x) := by ...
+
+-- The inductive definition of matchertext.
+inductive MT (Pi : Set (α × α)) : List α → Prop where
+  | flat (n : List α) (h : ∀ x ∈ n, Nonmatcher Pi x) : MT Pi n
+  | nest (m₁ m₂ m₃ : List α) (o c : α) (hp : (o, c) ∈ Pi)
+         (h₁ : MT Pi m₁) (h₂ : MT Pi m₂) (h₃ : MT Pi m₃) :
+      MT Pi (m₁ ++ [o] ++ m₂ ++ [c] ++ m₃)
+
+-- Net matcher depth: +1 per opener, -1 per closer, 0 per nonmatcher. Noncomputable since only
+-- a host implementation would need a computable version.
+noncomputable def delta (x : α) : Int := if Opener Pi x then 1 else if Closer Pi x then -1 else 0
+noncomputable def depth (l : List α) : Int := (l.map (delta Pi)).sum
+
+-- Lemma: depth is additive over concatenation.
+theorem depth_append (a b : List α) : depth Pi (a ++ b) = depth Pi a + depth Pi b := by ...
+
+-- Lemma: one character's contribution.
+theorem depth_singleton (x : α) :
+    depth Pi [x] = (if Opener Pi x then 1 else if Closer Pi x then -1 else 0) := by ...
+
+-- Lemma (balanced): a matchertext string has net depth 0, since it is well balanced.
+theorem depth_zero
+    (hdisj : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    {m : List α} (hm : MT Pi m) : depth Pi m = 0 := by ...
+
+-- Lemma (floor, the crux): no prefix of a matchertext string dips below depth 0, so
+-- a reader tracking matcher balance never underflows inside the embedding.
+theorem depth_prefix_nonneg
+    (hdisj : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    {m : List α} (hm : MT Pi m) :
+    ∀ p, p <+: m → 0 ≤ depth Pi p := by ...
+
+-- Theorem (L1): placing a matchertext value m in a hole closed by c and reading to
+-- balance recovers exactly m: every prefix of m stays at depth ≥ 0, m itself returns
+-- to 0, and c is the first character to drive the depth negative, so the balance
+-- boundary is precisely |m|. It follows from the three lemmas above: the boundary
+-- result is a corollary, not new machinery.
+theorem embed_boundary
+    (hdisj : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    {m : List α} (hm : MT Pi m) {c : α} (hc : Closer Pi c) :
+    (∀ p, p <+: m → 0 ≤ depth Pi p)
+      ∧ depth Pi m = 0
+      ∧ depth Pi (m ++ [c]) = -1 := by ...
+\end{lstlisting}

--- a/injection-research/doc/classify.tex
+++ b/injection-research/doc/classify.tex
@@ -1,0 +1,61 @@
+\section{Classification}
+\label{sec:classify}
+
+We classify each injection CVE along two axes: the \emph{weakness family}
+(rooted in the CWE taxonomy) and the injection \emph{syntax type}: the
+embedded language the attack targets, such as SQL, HTML, shell, or LDAP.
+The syntax axis is the one that matters for matchertext, because prevention
+depends on how the untrusted value is delimited in the target language, not on
+how the weakness is categorized.
+
+\paragraph{Injection gate.}
+A CVE is treated as injection-related if it carries any CWE in the
+\mbox{CWE-74} (``Injection'') subtree (computed from the CWE ChildOf
+hierarchy across all enrichment sources) or if its description matches a
+phrase rule for a known injection class.
+This yields \textbf{91{,}760} injection CVEs, \textbf{26.4\%} of published
+records, spanning 351 distinct CWEs.
+
+\paragraph{Layered labeling.}
+Each CVE's syntax type is resolved by a fallback chain, ordered from most to
+least reliable, mirroring the content-classifier methodology of the matchertext
+empirical study~\cite{matchertext}:
+
+(1) a deterministic map from specific CWEs (\eg \mbox{CWE-89}$\rightarrow$SQL,
+\mbox{CWE-79}$\rightarrow$HTML, \mbox{CWE-78}$\rightarrow$shell);
+
+(2) phrase rules over the CNA description (``SQL injection'', ``cross-site
+scripting'', ``command injection'', \dots);
+
+(3) a character-trigram naive-Bayes classifier trained on the CWE- and
+rule-labeled set, applied to the still-unlabeled remainder above a confidence
+margin; and
+
+(4) an explicit \texttt{unknown} bucket.
+
+\noindent Of the injection CVEs, 82{,}817 (90\%) are labeled deterministically from CWEs,
+7{,}657 from phrase rules, 1{,}160 from naive Bayes, and only 126 remain
+unknown, so the classification rests overwhelmingly on the deterministic
+layers.
+
+\paragraph{Label accuracy.}
+Only the naive-Bayes layer is statistical, and it is both the smallest (1.3\% of
+labels) and the only one we can score directly: on a held-out set of 8{,}948
+CVEs it reaches a weighted precision of \textbf{0.885} and recall of
+\textbf{0.853} at 97\% coverage, and it is strongest exactly where the
+prevention analysis is most sensitive (HTML/DOM 0.98/0.89, SQL 0.85/0.90),
+weakest on the small execution-sink classes it labels least often
+(code/eval 0.56/0.74).
+The deterministic layers carry the remaining 98\% of labels and rest on the
+CWE-to-syntax map, whose accuracy we do not independently validate.
+Since that map dominates the syntax labels the projection of \cref{sec:prevent}
+is computed from, we export an audit sample of 75 CVEs from each labeling layer,
+over-sampling the rare and least reliable ones.
+
+\paragraph{Weakness families.}
+Aggregated to families, the corpus is dominated by rendering injection
+(primarily cross-site scripting) and query injection (majority of SQL),
+followed by command injection and code/expression injection.
+Because family and syntax are distinct axes (CRLF header injection and XSS
+share the rendering family but differ sharply in matchertext-hostability), the
+prevention analysis works from the finer syntax axis throughout.

--- a/injection-research/doc/concl.tex
+++ b/injection-research/doc/concl.tex
@@ -1,0 +1,21 @@
+\section{Conclusion}
+\label{sec:concl}
+
+Measured against a reproducible corpus of 91{,}760 injection vulnerabilities,
+the matchertext discipline is structurally applicable to a large and
+concentrated majority of the injection landscape: the recorded payloads of 82\%
+of attacks for which we could recover one are contained by a matcher-delimited
+slot under a matchertext-aware host, and at most 80\% of all injection CVEs
+target a syntax such a host can delimit.
+The corpus also shows the shape of the containment, not only its size: it
+divides into inert embedding and outright rejection along the host language's
+native delimiter, the division \cref{sec:resist} derives, though the ratio
+between the two is a property of these recorded payloads rather than of an
+adaptive attacker.
+The residue falls along the two conditions of \cref{sec:threat}: execution sinks,
+where the host runs the value by design, and contexts whose delimiters are not
+matchers, neither of which any delimiting discipline can reach.
+The pipeline, corpus manifest, and per-skeleton rewrites are the concrete basis
+for extending this measurement beyond the sources studied here and for pairing
+the structural argument with the usability questions that adoption ultimately
+turns on.

--- a/injection-research/doc/data.tex
+++ b/injection-research/doc/data.tex
@@ -1,0 +1,55 @@
+\section{Data sources}
+\label{sec:data}
+
+Every source is keyed on the CVE identifier, so no vulnerability is duplicated;
+each additional database contributes enrichment or PoC rows rather than a second
+copy of the record.
+All sources are snapshot-pinned by git commit or content hash in a manifest, so
+the corpus is reproducible.
+
+\paragraph{Identity and enrichment.}
+The \href{https://github.com/CVEProject/cvelistV5}{MITRE CVE List}
+(\texttt{cvelistV5}) is the canonical record of identity, CNA provenance, and
+description.
+\href{https://nvd.nist.gov/vuln/data-feeds}{NVD} supplies normalized CWE, CPE,
+and CVSS; \href{https://github.com/cisagov/vulnrichment}{CISA Vulnrichment}
+backfills recent CWE/CVSS via its ADP container;
+\href{https://github.com/cisagov/kev-data}{CISA KEV} marks known-exploited CVEs;
+\href{https://www.first.org/epss/}{FIRST EPSS} supplies exploit-likelihood
+scores; and the \href{https://cwe.mitre.org/}{MITRE CWE list} provides the
+weakness hierarchy used for classification.
+\href{https://github.com/github/advisory-database}{GitHub Security Advisories},
+\href{https://access.redhat.com/security/data}{Red~Hat}, and
+\href{https://security-tracker.debian.org/tracker/}{Debian} add further CWE,
+CVSS, severity, and fix-state signals through their CVE aliases.
+Because the same CVE can carry different weakness labels from different sources,
+enrichment is kept \emph{source-separated}: each CWE or CVSS row is tagged with
+its origin rather than merged, which both preserves provenance and lets us
+measure cross-source disagreement.
+
+\paragraph{Proof-of-concept payloads.}
+Four PoC databases supply real attack strings:
+\href{https://gitlab.com/exploit-database/exploitdb}{Exploit-DB}, the
+\href{https://github.com/projectdiscovery/nuclei-templates}{Nuclei detection
+templates}, the
+\href{https://github.com/rapid7/metasploit-framework}{Metasploit Framework}
+modules, and the
+\href{https://github.com/nomi-sec/PoC-in-GitHub}{nomi-sec PoC-in-GitHub} index.
+The first three are cloned locally so that a payload can be extracted from the
+exploit file; the last contributes links only.
+PoC references are unified in a single table, with a local path where a payload
+is extractable.
+Because exploit code is dual-use, the corpus stores only links, identifiers, and
+locally-extracted payload fragments; no exploit files are redistributed.
+
+\paragraph{Scale.}
+The pinned snapshot comprises \textbf{365{,}310} CVE records
+(\textbf{347{,}651} in the \texttt{PUBLISHED} state).
+Across all categories the PoC databases link to 25{,}041 CVEs (Exploit-DB),
+8{,}975 (PoC-in-GitHub), 4{,}256 (Nuclei), and 3{,}106 (Metasploit); their
+coverage of the injection subset is reported with the results in
+\cref{sec:results}.
+A key methodological caveat is that these sources have different, sometimes
+mutable, update cadences (NVD in particular re-scores CVEs continuously), so
+the analysis fixes a dated snapshot and treats ``field missing in source'' as
+distinct from ``property absent in the vulnerability.''

--- a/injection-research/doc/intro.tex
+++ b/injection-research/doc/intro.tex
@@ -1,0 +1,52 @@
+\section{Introduction}
+\label{sec:intro}
+
+Injection vulnerabilities arise when untrusted data crosses a language boundary
+and is misinterpreted as structure rather than as inert content: a quote that
+closes a SQL string literal, an angle bracket that opens an HTML tag, a
+semicolon that starts a new shell command.
+Despite decades of mitigations (parameterized queries, context-sensitive
+output encoding, allowlisting), injection continues to dominate vulnerability
+disclosures, because each defense is specific to one host language and one
+syntactic context, and each is applied by hand at the point of use.
+
+The \emph{matchertext} discipline~\cite{matchertext} proposes a single,
+language-independent structural rule: the ASCII matcher pairs \verb|()|,
+\verb|[]|, and \verb|{}| must always match.
+Under this rule, a host language can delimit an untrusted value with a matcher
+pair and read it to matcher balance; to escape its slot the value would have to
+emit an unmatched matcher, which is not valid matchertext and is escaped on the
+way in.
+The canonical injection \verb|' OR '1'='1| illustrates the mechanism: hosted as
+\verb|WHERE name = [| \emph{value} \verb|]|, the quote that would have closed
+the string literal is now ordinary text inside the matched region, and the
+tautology cannot break out.
+
+This paper asks what a matchertext-based defense would guarantee, under what
+assumptions, and how much of the real injection landscape it could reach.
+We make four contributions:
+\begin{itemize}
+\item	A reproducible, snapshot-pinned corpus (\cref{sec:data}) that unifies
+	the official CVE record with normalized enrichment and four
+	proof-of-concept databases, so that classification, exploitation
+	signals, and real attack payloads can be joined on a common key.
+\item	A two-axis, multi-source classifier (\cref{sec:classify}) that labels
+	each injection CVE by weakness family and by the embedded
+	\emph{syntax} it targets, and a syntactic-skeleton grouping that
+	clusters attacks by structural shape (\cref{sec:results}).
+\item	A precise threat model and security property (\cref{sec:threat}) that
+    states the guarantee as an \emph{inertness} invariant, distinguishes it
+    from the weaker closure theorem it is easily conflated with, and reduces
+    it to three named premises; the load-bearing boundary premise we
+    discharge with a machine-checked Lean proof (\cref{sec:appendix:lean}).
+\item	An empirical measurement of matchertext's structural reach (\cref{sec:prevent}):
+	each skeleton is rewritten to its matchertext-equivalent and checked
+	for breakout, yielding both a measured figure over payload-backed CVEs
+	and a projection over the full injection corpus.
+\end{itemize}
+
+A vulnerability is tallied as structurally containable only where the mechanism
+holds structurally, and the payload-backed and projected figures are reported
+separately, each over its own subset.
+Both figures assume a matchertext-aware host and characterize attack structure,
+not a deployed defense.

--- a/injection-research/doc/main.tex
+++ b/injection-research/doc/main.tex
@@ -1,0 +1,98 @@
+\documentclass[fullpage,twocolumn]{article}
+\pdfoutput=1
+
+\usepackage{times}
+\usepackage{xspace}
+\usepackage{cite} % sort citation numbers
+\usepackage[hyperindex,breaklinks,colorlinks,
+	    linkcolor=blue,citecolor=blue,urlcolor=black]{hyperref}
+\usepackage{cleveref}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{xurl} % allow long URLs in the bibliography to break anywhere
+\usepackage[T1]{fontenc}
+\usepackage{listings}
+\lstdefinelanguage{Lean}{
+  morekeywords={inductive,theorem,def,where,variable,import,Prop,Set,List,Type,noncomputable,open},
+  morecomment=[l]{--},
+  morecomment=[s]{/-}{-/},
+  sensitive=true,
+}
+\lstset{
+  language=Lean,
+  basicstyle=\ttfamily\scriptsize,
+  commentstyle=\itshape,
+  columns=fullflexible,
+  keepspaces=true,
+  extendedchars=true,
+  breaklines=true,
+  showstringspaces=false,
+  literate=
+    {α}{{$\alpha$}}1
+    {Σ}{{$\Sigma$}}1
+    {Π}{{$\Pi$}}1
+    {∃}{{$\exists$}}1
+    {∈}{{$\in$}}1
+    {∨}{{$\lor$}}1
+    {∧}{{$\land$}}1
+    {¬}{{$\lnot$}}1
+    {×}{{$\times$}}1
+    {→}{{$\to$}}1
+    {∀}{{$\forall$}}1
+    {≤}{{$\leq$}}1
+    {≥}{{$\geq$}}1
+    {₁}{{$_1$}}1
+    {₂}{{$_2$}}1
+    {₃}{{$_3$}}1
+}
+\usepackage{upquote}
+
+%%%%%%%%%%%%%%%%%%%%%%
+
+% Select one or other if want to see comments.
+\long\def\com#1{}
+%\long\def\com#1{{\bf \sc comment: }{\small [#1]}{\bf \sc\ endcomment}\newline}
+
+\newcommand{\xxx}[1]{}
+%\newcommand{\xxx}[1]{{\color{red} {\bf XXX }{\small [#1]}}}
+
+% Common abbreviations
+\newcommand{\ie}{{\em i.e.},\xspace}
+\newcommand{\eg}{{\em e.g.},\xspace}
+
+%%%%%%%%%%%%%%%%%%%%%%
+
+\begin{document}
+
+\title{Matchertext: An Empirical Analysis of Injection Vulnerabilities \\
+	\Large{%
+	~\\
+	\url{https://github.com/dedis/matchertext}}}
+
+\author{Bryan Ford, Antoine Bastide \\ EPFL}
+
+\maketitle
+
+\input{abs}
+
+\tableofcontents
+
+\input{intro}
+\input{motivation}
+\input{data}
+\input{classify}
+\input{results}
+\input{threat}
+\input{resist}
+\input{prevent}
+\input{concl}
+
+\appendix
+\onecolumn
+\input{appendix}
+\twocolumn
+
+\bibliographystyle{plain}
+\bibliography{refs}
+
+\end{document}

--- a/injection-research/doc/motivation.tex
+++ b/injection-research/doc/motivation.tex
@@ -1,0 +1,183 @@
+\section{Background and motivation}
+\label{sec:motivation}
+
+Injection remains among the most damaging and persistent classes of software
+vulnerability. This section surveys the breadth of the problem beyond its most
+familiar members, its measured prevalence and cost, and why the very machinery
+built to contain it has itself become a recurring source of vulnerabilities:
+the motivation for the structural approach this thesis evaluates.
+
+\subsection{A wider family of embedding hazards}
+\label{sec:bg:hazards}
+
+SQL injection and XSS are only the most familiar members
+of a much larger family that share the boundary-crossing cause of \cref{sec:intro}.
+The same failure recurs across many more language pairs than those two,
+and produces symptoms well beyond information disclosure.
+
+Several are, like SQL injection, outright remote compromises.
+In the 2021 Log4Shell vulnerability,
+a \verb|${jndi:...}| sequence appearing anywhere in a logged string
+was expanded by Log4j's message interpolation into a remote lookup
+that loaded and executed attacker-supplied code~\cite{cve2021log4shell}.
+Command injection arises when user input reaches a shell without proper quoting,
+so that metacharacters such as \verb|;| or \verb|&|
+break out of the intended single argument~\cite{owasp_cmdinjection}.
+Spreadsheet formula injection turns exported data into code:
+a field beginning with \verb|=| is re-interpreted as a formula
+when a CSV export is opened in a spreadsheet,
+as in an Azure activity-log entry
+that executed on an administrator's machine on download~\cite{gietzen18csv}.
+Server-side template injection embeds user input into a template
+instead of passing it as data,
+letting an expression such as \verb|{{7*7}}| reach the template engine
+and frequently the whole server~\cite{portswigger_ssti},
+while the analogous client-side attack
+breaks out of the AngularJS expression sandbox
+to run arbitrary JavaScript~\cite{peguero16angular}.
+Even purpose-built defenses are not immune:
+the DOMPurify sanitizer has been bypassed by \emph{mutation} XSS,
+in which the browser's own parser rewrites already-sanitized markup
+back into an executable form~\cite{heyes20mxss}.
+
+Other members corrupt data or deny service rather than disclose it.
+YAML's implicit typing silently coerces values,
+so a list entry \verb|NO|, a country code, parses as the boolean false,
+the widely cited ``Norway problem''~\cite{oconnor23yaml}.
+A regular expression with nested quantifiers
+fed adversarial input backtracks catastrophically and hangs the program,
+a regular-expression denial of service~\cite{owasp_redos};
+and the XML ``billion laughs'' attack
+expands a kilobyte of nested entity definitions into gigabytes,
+exhausting memory during parsing~\cite{sullivan09xml}.
+
+The maintainability face of the same problem
+is the leaning toothpick syndrome,
+and history shows that ad-hoc syntactic fixes tend to backfire:
+PHP's \verb|magic_quotes| feature auto-escaped quotes in request data
+to forestall injection,
+but did so inconsistently, invited double-escaping bugs,
+and was eventually deprecated~\cite{php_magicquotes}.
+What unites the largest of these cases is structural:
+content meant to be inert data is read as syntax
+because a bracket or quote within it escapes its intended region.
+That is exactly the failure a matcher-balance discipline is built to resist,
+and because it recurs across the injection and markup attacks above
+rather than in any single language pair,
+one structural discipline can address the breakout-based members at once---as
+distinct from the execution and algorithmic members (template evaluation, ReDoS,
+entity expansion) it cannot.
+
+
+\subsection{The prevalence and cost of injection failures}
+\label{sec:bg:prevalence}
+
+These failures are neither rare nor fading.
+Injection has appeared in every edition of the OWASP Top~10
+web application security risks since 2010,
+and since the 2021 edition it subsumes cross-site scripting~\cite{owasp_top10_2021}.
+The underlying weaknesses top MITRE's CWE Top~25 as well:
+in the 2025 ranking,
+cross-site scripting (CWE-79) is first
+and SQL injection (CWE-89) second~\cite{cwe_top25_2025}.
+The absolute volumes are large.
+OWASP's 2025 Injection category maps to 62,445 recorded CVEs,
+of which it attributes more than 30,000 to XSS
+and more than 14,000 to SQL injection~\cite{owasp_top10_2025}.
+Independent scanning corroborates this:
+Edgescan's 2025 report attributes 28.28\% of critical and high-severity
+web and API findings to SQL injection and a further 17\% to XSS~\cite{edgescan25},
+and Veracode has reported XSS in 47\% and SQL injection in 28\%
+of the applications it tested~\cite{veracode_soss}.
+The cost of a single failure can be severe:
+the 2015 TalkTalk breach, an SQL injection,
+exposed the data of over 150,000 customers
+and led to a regulatory fine~\cite{ico_talktalk}.
+
+More telling for our purposes is \emph{why} these bugs persist.
+The escaping and context-sensitive sanitization
+that the preceding sections describe as complex
+are empirically error-prone.
+In one controlled study,
+all ten programmers asked to fix an XSS flaw
+with a standard output-encoding library
+failed to remove it completely~\cite{wijayarathna18esapi};
+an analysis of real PHP applications
+found them carrying far more distinct sanitizers than syntactic contexts,
+one application defining 95 sanitization functions
+against thousands of output sites,
+an arrangement in which selecting the wrong encoder for a context
+is both easy and common~\cite{weinberger11xss}.
+The risky patterns remain widespread:
+a 2024 study of nearly a million GitHub projects
+found SQL assembled by string concatenation
+in 42\% of the Java, 56\% of the C\#, and 91\% of the PHP files examined,
+the construction from which injection arises
+once untrusted input reaches the query structure~\cite{dennis24sql}.
+
+The record is consistent and stark:
+injection and XSS are common, severe, and long-lived,
+and the escaping and sanitization meant to prevent them
+are difficult and routinely misused.
+That is precisely the burden
+a simpler, uniform, host-independent \emph{check} could relieve,
+and pursuing it is the aim of the rest of this paper.
+
+
+\subsection{The sanitizer as attack surface}
+\label{sec:bg:sanitizer}
+
+The machinery built to perform this escaping
+is itself substantial code, and itself a recurring source of vulnerabilities.
+A production HTML sanitizer must track
+the host parser's full and quirk-laden behavior,
+so the components are not small:
+DOMPurify's core file runs to roughly 2,400 lines,
+and project-wide the larger sanitizers reach tens of thousands,
+HTML Purifier and OWASP's ESAPI each near 40,000
+and Python's Bleach around 15,000.
+Because such a sanitizer is correct only while its model
+matches every browser exactly,
+each divergence becomes a bypass,
+and the bypasses recur as named classes:
+mutation XSS, in which sanitized markup turns executable
+once the browser reparses it~\cite{heiderich13mxss};
+parsing differentials, in which the sanitizer and the browser
+disagree about the same input~\cite{klein24parsing};
+and DOM clobbering, in which attacker-named elements
+subvert the security logic itself~\cite{khodayari23clobbering}.
+
+The result is a steady stream of flaws in the sanitizers themselves.
+DOMPurify has carried at least nine CVEs,
+publishing sixteen security advisories in under three months
+of 2026 alone~\cite{dompurify_advisories},
+and the Rails HTML sanitizer disclosed five CVEs on a single day~\cite{rails_sanitizer_cves};
+Bleach, sanitize-html, and HTML Purifier
+each have their own multi-entry histories.
+These counts include only flaws \emph{in} the sanitizers,
+not the far larger number they prevent downstream,
+and the point is not that sanitizers are dispensable.
+It is that a transformation which must re-implement
+another language's parser, and re-synchronize with it as it changes,
+is inherently a large attack surface.
+
+This is the concrete case for preferring a structural \emph{check}
+to a structural \emph{transformation}.
+Verifying that a value's matchers balance
+is host-independent and small,
+whereas a sanitizer must shadow the host language's parser and its quirks;
+the security literature has repeatedly reached the analogous conclusion,
+favoring safety by construction, typed template contexts,
+and parameterized queries over ad-hoc escaping~\cite{samuel11csas,momot16langsec,owasp_parameterization}.
+The check itself is a few lines of uniform, host-independent balance-counting,
+against tens of thousands of lines of parser-shadowing transformation
+that must be re-synchronized with every browser it shadows.
+The check is not the whole trusted base.
+A matchertext host must also end an embedded value by matcher balance
+and suppress its own decoding inside the hole,
+and the write path adds an encoder and its inverse (\cref{sec:threat}).
+Matchertext thus relocates trust rather than eliminating it:
+what must hold uniformly across languages shrinks to a small host-independent
+check, and what remains per host is a bounded change to a parser the host
+already owns, not a new artifact shadowing one it does not.
+

--- a/injection-research/doc/prevent.tex
+++ b/injection-research/doc/prevent.tex
@@ -1,0 +1,100 @@
+\section{Measuring matchertext containment}
+\label{sec:prevent}
+
+Matchertext contains an injection under mainly two conditions: the untrusted value lands in a slot
+a matchertext-aware host delimits with a matcher pair, and the value is itself
+valid matchertext, checked by the passive \textsc{Verify} scan rather than by
+escaping.
+An attack then fails one of two ways, by \emph{inert embedding} or by
+\emph{rejection}, and which route a real attack takes is a property of the
+payload, and so measurable against the corpus.
+
+\paragraph{Method.}
+For each of the 5{,}025 payload-backed CVEs we reuse its syntactic skeleton and decide two things:
+whether the target syntax is one a matchertext host can delimit with a matcher
+pair, and, if so, whether the skeleton passes \textsc{Verify}.
+A passing skeleton is contained by \emph{inert embedding}; a failing one is
+stopped by \emph{rejection}.
+This test characterizes the structure of each recorded payload under a
+matchertext-aware host; it does not exercise a deployed host parser, which we
+leave to future implementation work.
+
+\begin{table}[t]
+\centering
+\small
+\begin{tabular}{lrrr}
+\toprule
+Syntax & Inert embed & Rejected & Outside \\
+\midrule
+HTML / DOM (XSS)    & 2{,}772 &  13 & 219 \\
+SQL                 & 1{,}000 & 322 &   0 \\
+LDAP                &       0 &   3 &   0 \\
+NoSQL               &       1 &   0 &   0 \\
+\midrule
+Shell command       & --- & --- & 333 \\
+Code / eval         & --- & --- & 301 \\
+CRLF / header       & --- & --- &  29 \\
+Formula (CSV)       & --- & --- &  17 \\
+Template            & --- & --- &   5 \\
+XML                 & --- & --- &   4 \\
+Argument            & --- & --- &   3 \\
+Expression language & --- & --- &   3 \\
+\midrule
+Total               & 3{,}773 & 338 & 914 \\
+\bottomrule
+\end{tabular}
+\caption{Containment outcome by syntax over all \(5{,}025\) payload-backed CVEs.
+Contexts a matchertext host can delimit (upper block) are contained by inert
+embedding or by rejection; the \emph{Outside} column counts CVEs failing a
+condition of \cref{sec:threat}, either an execution sink (the HTML/DOM entries
+are \texttt{javascript:} URLs) or a context whose delimiters are not matchers.}
+\label{tab:mech}
+\end{table}
+
+\paragraph{Results.}
+Of the 5{,}025 payload-backed injection CVEs, the recorded payloads of
+\textbf{4{,}111} (\textbf{82\%}) are contained by a matcher-delimited slot that a
+matchertext-aware host reads to matcher balance, assuming no intervening
+decoding; the split turns on the host's native delimiter.
+The per-syntax mechanisms of \cref{sec:resist} appear directly in the corpus.
+LDAP is the pure rejection case: every real LDAP payload fails \textsc{Verify}
+(0 inert, 3 rejected), its parenthesis breakout carrying an unmatched \verb|)|.
+SQL and XSS, breaking out on nonmatchers, are overwhelmingly valid matchertext
+and embed inertly; the 322 SQL rejections additionally carry an unbalanced
+function or subquery parenthesis.
+The ratio between the two mechanisms is descriptive, not predictive.
+These payloads were written against quote and tag-delimited sinks; an attacker
+aware of a matcher-delimited slot would balance the matchers, shifting cases
+from rejection to inert embedding.
+Containment is unaffected, since both routes hold the value, but the split
+itself is a property of the recorded corpus rather than of an adaptive attacker.
+
+\paragraph{Where matchertext cannot help.}
+The remaining 914 payload-backed CVEs are outside both conditions, and divide
+along the two conditions they fail.
+545 target execution/semantic sinks (server-side templates, expression
+languages, code evaluation, spreadsheet formulas, and \verb|javascript:| URLs)
+where the host runs the contained value by design, so delimiting cannot stop
+it: the template payload \verb|{{7*7}}| is already valid matchertext yet is
+still executed.
+The other 369 target contexts delimited by non-matchers with no matcher hosting:
+shell command separators (\verb|;|~\verb-|-~\verb|&|), CR/LF header breaks, and
+the angle brackets of XML/XXE, none of which are matcher characters.
+
+\paragraph{Projection.}
+A payload is required to classify the mechanism, but the \emph{context}
+condition can be read from the syntax label alone.
+Projecting it onto the full corpus, at most \textbf{73{,}246} of the
+\textbf{91{,}760} injection CVEs (\textbf{80\%}) target a matcher-delimitable
+syntax.
+This is an upper bound, since a fraction of HTML/DOM cases are the
+\verb|javascript:| semantic sinks above, and the payload-backed subset puts a
+number on that fraction: 219 of the 3{,}004 HTML/DOM CVEs carrying a payload are
+such sinks, a rate of \textbf{7.3\%}.
+Applying it to the 50{,}884 HTML/DOM CVEs removes an estimated 3{,}710, for a
+central estimate of \textbf{69{,}536} (\textbf{76\%}) against the 80\% ceiling.
+The estimate assumes payload-backed CVEs carry sinks at the same rate as the
+rest, which their skew toward exploitable web bugs may not warrant.
+The reach of the discipline is thus bounded from below at the fragment level and
+from above at the syntax level, and the gap between 5{,}025 and 91{,}760 is
+payload availability, not a containment failure.

--- a/injection-research/doc/proof.lean
+++ b/injection-research/doc/proof.lean
@@ -1,0 +1,168 @@
+import Mathlib
+
+/- Premises given in the paper -/
+
+variable {α : Type*}              -- the alphabet Σ, kept abstract on purpose
+variable (Pi : Set (α × α))       -- the set of pairs Π
+
+--
+def Opener     (x : α)   : Prop := ∃ y, (x, y) ∈ Pi
+def Closer     (x : α)   : Prop := ∃ y, (y, x) ∈ Pi
+def Matcher    (x : α)   : Prop := Opener Pi x ∨ Closer Pi x
+def Nonmatcher (x : α)   : Prop := ¬ Matcher Pi x
+
+-- Prove: no opener can be a closer, and vice versa
+theorem disjoint
+    (h : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    (x : α) : ¬ (Opener Pi x ∧ Closer Pi x) := by
+  intro hx
+  rcases hx with ⟨ho, hc⟩
+  rcases ho with ⟨y, hy⟩
+  rcases hc with ⟨z, hz⟩
+  exact h x y z hy hz
+
+-- The inductive definition of Matchertext
+inductive MT (Pi : Set (α × α)) : List α → Prop where
+  | flat (n : List α) (h : ∀ x ∈ n, Nonmatcher Pi x) : MT Pi n
+  | nest (m₁ m₂ m₃ : List α) (o c : α) (hp : (o, c) ∈ Pi) (h₁ : MT Pi m₁) (h₂ : MT Pi m₂) (h₃ : MT Pi m₃) :
+      MT Pi (m₁ ++ [o] ++ m₂ ++ [c] ++ m₃)
+
+-- ============================================================================
+-- L1: reading a matched-delimited region "to matcher balance" recovers a
+-- well-defined region that is itself matchertext. Stated declaratively over the
+-- language `MT`.
+-- ============================================================================
+
+open Classical
+
+/-- Net matcher depth: +1 per opener, -1 per closer, 0 per nonmatcher.
+    `noncomputable` since only a host implementation would need a computable version. -/
+noncomputable def delta (x : α) : Int := if Opener Pi x then 1 else if Closer Pi x then -1 else 0
+noncomputable def depth (l : List α) : Int := (l.map (delta Pi)).sum
+
+-- Lemma: depth is additive over concatenation.
+theorem depth_append (a b : List α) : depth Pi (a ++ b) = depth Pi a + depth Pi b := by simp [depth]
+
+-- Lemma: a single character's contribution to the depth.
+theorem depth_singleton (x : α) : depth Pi [x] = (if Opener Pi x then 1 else if Closer Pi x then -1 else 0) := by simp [depth, delta]
+
+-- Lemma: a matchertext string has net depth zero.
+theorem depth_zero
+    (hdisj : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    {m : List α} (hm : MT Pi m) : depth Pi m = 0 := by
+  induction hm with
+  | flat n hn =>
+    induction n with
+    | nil => simp [depth]
+    | cons x xs ih =>
+      have hr : depth Pi (x :: xs) = depth Pi ([x] ++ xs) := by simp
+      have hx : Nonmatcher Pi x := by exact hn x (by simp)
+      have hxs : depth Pi xs = 0 := by
+        apply ih
+        intro x hx
+        exact hn x (by simp [hx])
+      have hopen : ¬ Opener Pi x := by
+        intro h
+        exact hx (Or.inl h)
+      have hclose : ¬ Closer Pi x := by
+        intro h
+        exact hx (Or.inr h)
+      have hdx : depth Pi [x] = 0 := by simp [depth, delta, hopen, hclose]
+      simp only [hr, depth_append, hxs, hdx]
+      omega
+  | nest a₁ a₂ a₃ o c hp h₁ h₂ h₃ ih₁ ih₂ ih₃ =>
+    have ho : Opener Pi o := ⟨c, hp⟩
+    have hc : Closer Pi c := ⟨o, hp⟩
+    have hco : ¬ Opener Pi c := fun hoc => disjoint Pi hdisj c ⟨hoc, hc⟩
+    have hdo: depth Pi [o] = 1 := by simp [depth_singleton, if_pos ho]
+    have hdc: depth Pi [c] = -1 := by simp [depth_singleton, if_neg hco, if_pos hc]
+    simp only [depth_append, ih₁, ih₂, ih₃, hdo, hdc]
+    omega
+
+-- Lemma (floor): no prefix of a matchertext string dips below depth zero, so a reader tracking matcher balance
+-- never underflows inside the embedded value.
+theorem depth_prefix_nonneg
+    (hdisj : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    {m : List α} (hm : MT Pi m) : ∀ p, p <+: m → 0 ≤ depth Pi p := by
+  induction hm with
+  | flat n hn =>
+    intro p hpre
+    have hp' : ∀ x ∈ p, Nonmatcher Pi x := fun x hx => hn x (hpre.subset hx)
+    have hmp : MT Pi p := MT.flat p hp'
+    have h : depth Pi p = 0 := depth_zero Pi hdisj hmp
+    have hh : 0 ≤ depth Pi p := by simp [h]
+    exact hh
+  | nest a₁ a₂ a₃ o c hp h₁ h₂ h₃ ih₁ ih₂ ih₃ =>
+    have ho : Opener Pi o := ⟨c, hp⟩
+    have hc : Closer Pi c := ⟨o, hp⟩
+
+    have hco : ¬ Opener Pi c := by
+      intro hoc
+      exact disjoint Pi hdisj c ⟨hoc, hc⟩
+
+    have hdo : depth Pi [o] = 1 := by simp [depth_singleton, if_pos ho]
+    have hdc : depth Pi [c] = -1 := by simp [depth_singleton, if_neg hco, if_pos hc]
+
+    have hz₁ : depth Pi a₁ = 0 := depth_zero Pi hdisj h₁
+    have hz₂ : depth Pi a₂ = 0 := depth_zero Pi hdisj h₂
+
+    intro p hpre
+    simp only [List.append_assoc] at hpre
+
+    -- ── peel a₁ ────────────────────────────────────────────────
+    rcases List.prefix_or_prefix_of_prefix hpre (List.prefix_append a₁ _) with h | h
+    · exact ih₁ p h
+    obtain ⟨p₁, rfl⟩ := h
+    rw [List.prefix_append_right_inj] at hpre
+    rw [depth_append, hz₁, zero_add]
+
+    -- ── peel [o] ───────────────────────────────────────────────
+    rcases List.prefix_or_prefix_of_prefix hpre (List.prefix_append [o] _) with h | h
+    · rcases p₁ with _ | ⟨y, ys⟩
+      · simp [depth]
+      · simp at h
+        obtain ⟨rfl, rfl⟩ := h
+        rw [hdo]
+        norm_num
+    obtain ⟨p₂, rfl⟩ := h
+    rw [List.prefix_append_right_inj] at hpre
+    rw [depth_append, hdo]
+
+    -- ── peel a₂ ────────────────────────────────────────────────
+    rcases List.prefix_or_prefix_of_prefix hpre (List.prefix_append a₂ _) with h | h
+    · have := ih₂ p₂ h; linarith
+    obtain ⟨p₃, rfl⟩ := h
+    rw [List.prefix_append_right_inj] at hpre
+    rw [depth_append, hz₂]
+
+    -- ── peel [c] ───────────────────────────────────────────────
+    rcases List.prefix_or_prefix_of_prefix hpre (List.prefix_append [c] _) with h | h
+    · rcases p₃ with _ | ⟨y, ys⟩
+      · simp [depth]
+      · simp at h
+        obtain ⟨rfl, rfl⟩ := h
+        rw [hdc]
+        norm_num
+    obtain ⟨p₄, rfl⟩ := h
+    rw [List.prefix_append_right_inj] at hpre
+    rw [depth_append, hdc]
+    have := ih₃ p₄ hpre
+    linarith
+
+/-- **L1** Placing a matchertext value `m` in a
+    matched pair `(o, c)` and reading to balance recovers exactly `m`: every prefix
+    of `m` stays at depth ≥ 0, `m` returns to 0, and the context-closer `c` is the
+    first character to drive the depth negative — so the balance boundary is
+    precisely `|m|`. It follows from the three lemmas above, showing the boundary
+    result is a corollary, not new machinery. -/
+theorem embed_boundary
+    (hdisj : ∀ x y z, (x, y) ∈ Pi → (z, x) ∈ Pi → False)
+    {m : List α} (hm : MT Pi m) {c : α} (hc : Closer Pi c) :
+    (∀ p, p <+: m → 0 ≤ depth Pi p) ∧ depth Pi m = 0 ∧ depth Pi (m ++ [c]) = -1 := by
+  have hzero : depth Pi m = 0 := depth_zero Pi hdisj hm
+  have hco : ¬ Opener Pi c := fun ho => disjoint Pi hdisj c ⟨ho, hc⟩
+  refine ⟨fun p hpre => depth_prefix_nonneg Pi hdisj hm p hpre, hzero, ?_⟩
+  rw [depth_append, hzero, depth_singleton, if_neg hco, if_pos hc]
+  norm_num
+
+-- 'embed_boundary' depends on axioms: [propext, choice, Quot.sound]

--- a/injection-research/doc/refs.bib
+++ b/injection-research/doc/refs.bib
@@ -1,0 +1,296 @@
+@misc{matchertext,
+  author = {Bryan Ford},
+  title  = {Matchertext: Towards Verbatim Interlanguage Embedding},
+  year   = {2026},
+  note   = {EPFL, Decentralized and Distributed Systems (DEDIS) Laboratory},
+  howpublished = {\url{https://github.com/dedis/matchertext}},
+}
+
+@misc{cvelist,
+  author = {{MITRE Corporation}},
+  title  = {{CVE} List {V5}},
+  howpublished = {\url{https://github.com/CVEProject/cvelistV5}},
+}
+
+@misc{nvd,
+  author = {{National Institute of Standards and Technology}},
+  title  = {National Vulnerability Database},
+  howpublished = {\url{https://nvd.nist.gov/}},
+}
+
+@misc{cwe,
+  author = {{MITRE Corporation}},
+  title  = {Common Weakness Enumeration},
+  howpublished = {\url{https://cwe.mitre.org/}},
+}
+
+@misc{kev,
+  author = {{Cybersecurity and Infrastructure Security Agency}},
+  title  = {Known Exploited Vulnerabilities Catalog},
+  howpublished = {\url{https://www.cisa.gov/known-exploited-vulnerabilities-catalog}},
+}
+
+@misc{epss,
+  author = {{Forum of Incident Response and Security Teams}},
+  title  = {Exploit Prediction Scoring System ({EPSS})},
+  howpublished = {\url{https://www.first.org/epss/}},
+}
+
+@misc{exploitdb,
+  author = {{OffSec}},
+  title  = {Exploit Database},
+  howpublished = {\url{https://gitlab.com/exploit-database/exploitdb}},
+}
+
+@book{clarke12sql,
+  author = {Justin Clarke},
+  title  = {{SQL} Injection Attacks and Defense},
+  publisher = {Syngress (Elsevier)},
+  address = {Waltham, MA},
+  edition = {2nd},
+  year   = {2012},
+}
+
+@inproceedings{alonso08ldap,
+  author = {Jos{\'e} Mar{\'i}a Alonso and Antonio Guzm{\'a}n
+    and Marta Beltr{\'a}n and Rodolfo Bord{\'o}n},
+  title  = {{LDAP} Injection \& Blind {LDAP} Injection in Web Applications},
+  booktitle = {Black Hat Europe},
+  year   = {2008},
+}
+
+@techreport{rfc4515,
+  author = {Mark Smith and Tim Howes},
+  title  = {Lightweight Directory Access Protocol ({LDAP}):
+    String Representation of Search Filters},
+  type   = {RFC},
+  number = {4515},
+  institution = {Internet Engineering Task Force (IETF)},
+  year   = {2006},
+  month  = jun,
+}
+
+@techreport{iso32000,
+  author = {{ISO}},
+  title  = {Document Management, Portable Document Format, Part 1: {PDF} 1.7},
+  type   = {Standard},
+  number = {ISO 32000-1:2008},
+  institution = {International Organization for Standardization},
+  year   = {2008},
+}
+
+@misc{heyes20pdf,
+  author = {Gareth Heyes},
+  title  = {Portable Data exFiltration: {XSS} for {PDFs}},
+  howpublished = {PortSwigger Research,
+    \url{https://portswigger.net/research/portable-data-exfiltration}},
+  year   = {2020},
+}
+
+
+% --- motivation section (moved from main paper 2.5-2.7) ---
+@misc{cve2021log4shell,
+	author = {{MITRE}},
+	title = {Apache {Log4j2} Remote Code Execution via {JNDI} Lookup},
+	howpublished = {CVE-2021-44228,
+		\url{https://nvd.nist.gov/vuln/detail/CVE-2021-44228}},
+	year = {2021},
+}
+
+@misc{cwe_top25_2025,
+	author = {{MITRE}},
+	title = {2025 {CWE} Top 25 Most Dangerous Software Weaknesses},
+	howpublished = {MITRE,
+		\url{https://cwe.mitre.org/top25/archive/2025/2025_cwe_top25.html}},
+	year = {2025},
+}
+
+@misc{dennis24sql,
+	author = {Dennis and others},
+	title = {Large-Scale Analysis of {GitHub} and {CVEs} to Determine
+		Prevalence of {SQL} Concatenations},
+	howpublished = {SciTePress,
+		\url{https://www.scitepress.org/publishedPapers/2024/128352/pdf/index.html}},
+	year = {2024},
+}
+
+@misc{dompurify_advisories,
+	author = {{cure53}},
+	title = {Security Advisories for {DOMPurify}},
+	howpublished = {GitHub,
+		\url{https://github.com/cure53/DOMPurify/security/advisories}},
+}
+
+@misc{edgescan25,
+	author = {{Edgescan}},
+	title = {2025 Vulnerability Statistics Report},
+	howpublished = {Edgescan},
+	year = {2025},
+}
+
+@misc{gietzen18csv,
+	author = {Spencer Gietzen},
+	title = {Cloud Security Risks: {Azure} {CSV} Injection Vulnerability},
+	howpublished = {Rhino Security Labs},
+	year = {2018},
+}
+
+@inproceedings{heiderich13mxss,
+	author = {Mario Heiderich and J{\"o}rg Schwenk and others},
+	title = {{mXSS} Attacks: Attacking Well-Secured Web-Applications
+		by Using {innerHTML} Mutations},
+	booktitle = {ACM Conference on Computer and Communications Security (CCS)},
+	year = {2013},
+}
+
+@misc{heyes20mxss,
+	author = {Gareth Heyes},
+	title = {Bypassing {DOMPurify} Again with Mutation {XSS}},
+	howpublished = {PortSwigger Research,
+		\url{https://portswigger.net/research/bypassing-dompurify-again-with-mutation-xss}},
+	year = {2020},
+}
+
+@misc{ico_talktalk,
+	author = {{Information Commissioner's Office}},
+	title = {{TalkTalk} Cyber Attack: How the {ICO} Investigation Unfolded},
+	howpublished = {ICO,
+		\url{https://ico.org.uk/about-the-ico/media-centre/talktalk-cyber-attack-how-the-ico-investigation-unfolded/}},
+	year = {2016},
+}
+
+@inproceedings{khodayari23clobbering,
+	author = {Soheil Khodayari and Giancarlo Pellegrino},
+	title = {It's ({DOM}) Clobbering Time: Attack Techniques, Prevalence, and Defenses},
+	booktitle = {IEEE Symposium on Security and Privacy (S\&P)},
+	year = {2023},
+}
+
+@misc{klein24parsing,
+	author = {David Klein and Krzysztof Kotowicz and Martin Johns},
+	title = {Bypassing {HTML} Sanitizer via Parsing Differentials},
+	howpublished = {Preprint,
+		\url{https://www.ias.cs.tu-bs.de/publications/parsing_differentials.pdf}},
+	year = {2024},
+}
+
+@inproceedings{momot16langsec,
+	author = {Falcon Darkstar Momot and Sergey Bratus and Sven M. Hallberg
+		and Meredith L. Patterson},
+	title = {The Seven Turrets of Babel: A Taxonomy of {LangSec} Errors
+		and How to Expunge Them},
+	booktitle = {IEEE Cybersecurity Development Conference (SecDev)},
+	year = {2016},
+}
+
+@misc{oconnor23yaml,
+	author = {Colm O'Connor},
+	title = {The {Norway} Problem: Why {StrictYAML} Refuses to Do Implicit Typing},
+	howpublished = {StrictYAML documentation},
+	year = {2023},
+}
+
+@misc{owasp_cmdinjection,
+	author = {{OWASP}},
+	title = {Command Injection},
+	howpublished = {OWASP Community,
+		\url{https://owasp.org/www-community/attacks/Command_Injection}},
+}
+
+@misc{owasp_parameterization,
+	author = {{OWASP}},
+	title = {Query Parameterization Cheat Sheet},
+	howpublished = {OWASP Cheat Sheet Series,
+		\url{https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html}},
+}
+
+@misc{owasp_redos,
+	author = {{OWASP}},
+	title = {Regular Expression Denial of Service ({ReDoS})},
+	howpublished = {OWASP Community,
+		\url{https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS}},
+}
+
+@misc{owasp_top10_2021,
+	author = {{OWASP}},
+	title = {{A03:2021} Injection},
+	howpublished = {OWASP Top 10:2021,
+		\url{https://owasp.org/Top10/A03_2021-Injection/}},
+	year = {2021},
+}
+
+@misc{owasp_top10_2025,
+	author = {{OWASP}},
+	title = {{A05:2025} Injection},
+	howpublished = {OWASP Top 10:2025,
+		\url{https://owasp.org/Top10/A05_2025-Injection/}},
+	year = {2025},
+}
+
+@misc{peguero16angular,
+	author = {Ksenia Peguero},
+	title = {An Escape Room Called the {AngularJS} Sandbox},
+	howpublished = {Synopsys},
+	year = {2016},
+}
+
+@misc{php_magicquotes,
+	author = {{The PHP Group}},
+	title = {Magic Quotes},
+	howpublished = {PHP Manual,
+		\url{https://www.php.net/manual/en/security.magicquotes.php}},
+}
+
+@misc{portswigger_ssti,
+	author = {{PortSwigger}},
+	title = {Server-Side Template Injection},
+	howpublished = {Web Security Academy,
+		\url{https://portswigger.net/web-security/server-side-template-injection}},
+}
+
+@misc{rails_sanitizer_cves,
+	author = {Mike Dalessio},
+	title = {{rails-html-sanitizer} 1.6.1 Addresses Multiple {CVEs}},
+	howpublished = {Ruby on Rails Security Announcements,
+		\url{https://discuss.rubyonrails.org/t/rails-html-sanitizer-v1-6-1-addresses-multiple-cves/88092}},
+	year = {2024},
+}
+
+@inproceedings{samuel11csas,
+	author = {Mike Samuel and Prateek Saxena and Dawn Song and Pongsin Poosankam},
+	title = {Context-Sensitive Auto-Sanitization in Web Templating Languages
+		Using Type Qualifiers},
+	booktitle = {ACM Conference on Computer and Communications Security (CCS)},
+	year = {2011},
+}
+
+@article{sullivan09xml,
+	author = {Bryan Sullivan},
+	title = {{XML} Denial of Service Attacks and Defenses},
+	journal = {MSDN Magazine},
+	year = {2009},
+}
+
+@misc{veracode_soss,
+	author = {{Veracode}},
+	title = {State of Software Security, Volume 11},
+	howpublished = {Veracode},
+	year = {2020},
+}
+
+@inproceedings{weinberger11xss,
+	author = {Joel Weinberger and Prateek Saxena and Devdatta Akhawe
+		and Matthew Finifter and Richard Shin and Dawn Song},
+	title = {A Systematic Analysis of {XSS} Sanitization
+		in Web Application Frameworks},
+	booktitle = {European Symposium on Research in Computer Security (ESORICS)},
+	year = {2011},
+}
+
+@misc{wijayarathna18esapi,
+	author = {Chamila Wijayarathna and Nalin A. G. Arachchilage},
+	title = {Fighting Against {XSS} Attacks: A Usability Evaluation
+		of {OWASP} {ESAPI} Output Encoding},
+	howpublished = {arXiv:1810.01017, \url{https://arxiv.org/abs/1810.01017}},
+	year = {2018},
+}

--- a/injection-research/doc/resist.tex
+++ b/injection-research/doc/resist.tex
@@ -1,0 +1,164 @@
+\section{Injection resistance by matcher-delimiting untrusted input}
+\label{sec:resist}
+
+Delimiting untrusted input with a matcher pair rather than a nonmatcher (such as
+a quote) prevents that input from breaking out of its slot, since escaping the
+delimiter would require an unmatched matcher, which the always-embeddability
+theorem of matchertext forbids in valid matchertext~\cite{matchertext}.
+We develop this first for SQL injection, then for cross-site scripting, whose
+several distinct HTML escaping contexts collapse to one discipline.
+The same argument then covers two settings where the host already delimits with
+matchers, so the discipline asks for no new syntax: LDAP directory filters,
+whose parenthesised assertions are matcher-delimited already, and the PDF
+document format, whose literal strings already require matcher balance.
+
+\subsection{Preventing SQL injection}
+\label{sec:resist:sql}
+
+The discipline is worth making concrete in the setting that most sharply
+motivates it, untrusted input embedded into a query language such as SQL.
+Recall the classic vulnerability of \cref{sec:intro}: a server composes a clause
+like \verb|"WHERE name = '"+userName+"'"|, and a \verb|userName| containing a
+quote closes the literal early and appends attacker-controlled
+SQL~\cite{clarke12sql}, the quote being dangerous precisely because it is a
+\emph{nonmatcher} the discipline leaves unconstrained.
+We instead delimit each untrusted value with the matcher pair
+\verb|[|$\dots$\verb|]| and have the query processor treat the content as
+embedded matchertext, ending it by matcher balance rather than by scanning for a
+closing quote, so the clause becomes \verb|WHERE name = [|\textit{userName}\verb|]|.
+
+Concretely, the canonical injection \verb|x' OR '1'='1| now fails two ways.
+Supplied verbatim it contains no matchers, so it embeds as the literal name
+\verb|x' OR '1'='1|, its quotes inert because nothing inside \verb|[|$\dots$\verb|]|
+is read as SQL.
+When adapted to attack the new delimiters, as in \verb|] OR 1=1 --|, it carries
+an unmatched \verb|]| which is not matchertext, and thus cannot embed at all.
+Because the guarantee depends only on the delimiter being a matcher, not on what
+the value denotes, it holds wherever untrusted input appears, not only string
+values but numbers and even identifiers such as table or column names.
+That last case is a strength over parameterized queries (prepared statements),
+whose placeholders bind only \emph{values}: an identifier cannot be parameterized
+and is usually left to ad-hoc allow-listing, whereas \verb|FROM [|\textit{table}\verb|]|
+covers it directly.
+Which tables a caller may name remains an authorization question, distinct from
+injection.
+
+Free-form fields, a name, a comment, a search box, may legitimately contain
+unmatched matchers (\eg a fragment \verb|f(x| or \verb|smile :]|), so rather than
+reject them we pass them through a total encoder \textsc{ToMatchertext}$(v)$ that
+escapes only the \emph{unmatched} matchers in $v$~\cite{matchertext}, and decode
+on read.
+Defined on every input, it never rejects, and because its escapes are themselves
+balanced its output is always valid matchertext, its sole and host-independent
+obligation, checkable in isolation by the \textsc{Verify} scan and saying nothing
+about SQL.
+The failure mode is therefore benign: an encoder bug yields mis-encoded
+\emph{data}, never a breakout, where in conventional escaping one missed case
+\emph{is} the injection.
+
+Under a matchertext-aware host that ends each value by matcher balance,
+matchertext offers a \emph{structural} property: no valid-matchertext value, in
+any position, can escape its delimiters or alter the surrounding query structure,
+closing off the sub-class of injection that depends on breaking out of a
+delimiter.
+This is a syntactic-closure property; it does not by itself establish that later
+decoding, reparsing, or execution of the contained value is safe.
+It does not adjudicate whether a well-formed value is \emph{authorized}, which
+remains a matter of access control, and it complements rather than replaces
+parameterized queries where those already suffice.
+
+\subsection{Cross-site scripting across HTML contexts}
+\label{sec:resist:xss}
+
+The same discipline addresses cross-site scripting across three different
+injection sites, each with its own escaping regime.
+A value placed as element content, between \verb|<div>| and \verb|</div>|, breaks
+out on \verb|<| or \verb|&|; the same value in a quoted attribute,
+\verb|<input value="|\emph{v}\verb|">|, breaks out on the active quote rather than
+\verb|<|, and in an unquoted attribute the breakout set widens to whitespace and
+\verb|=|; a value in a script body, \verb|<script>var n="|\emph{v}\verb|"</script>|,
+has two independent exits, the JavaScript string quote and the raw
+\verb|</script>| sequence that ends the element regardless of JavaScript syntax.
+The recurring bug is applying one escaper, usually HTML-entity encoding, in all
+three contexts, where it is correct only for element content.
+
+Matcher-delimiting collapses the three to a single discipline, exactly as for
+SQL: each hole is read verbatim up to a matched close bracket and the host
+performs no transformation, using matchertext markup forms~\cite{matchertext}
+(\eg \verb|<div [|\emph{v}\verb|]>|, \verb|value=[|\emph{v}\verb|]|, and
+\verb|<![MDATA[|\emph{v}\verb|]]>|).
+Because the matchers are \verb|()[]{}| and not \verb|<>|, the characters that
+drove every breakout above, \verb|<|, \verb|&|, the quote, and even the literal
+\verb|</script>| sequence, become ordinary data inside a matched hole: the parser
+counts brackets rather than scanning for tags, so an injected
+\verb|<img src=x onerror=steal()>| is inert text.
+The three context-specific sanitizers thus reduce to the single \textsc{Verify}
+recognizer, the same one used for SQL, whose only rejection is an unmatched
+matcher.
+
+As with the numeric-context caveat for SQL, the guarantee is structural and stops
+at sinks that execute their contents by design.
+A payload kept dutifully inside \verb|<a href=[|\emph{v}\verb|]>| stays within the
+attribute yet still runs when \emph{v} is a \verb|javascript:| URL, because that
+is an execution context, not a structural breakout; an \verb|onerror| handler is
+the same.
+Such semantic sinks are out of scope.
+A second limit is expressiveness: matchertext content is verbatim text and cannot
+carry child markup, which is exactly right for embedding an untrusted string as
+inert data but is not a substitute for rendering a user's rich HTML, a harder
+problem left to allow-list sanitizers.
+The clean guarantee covers the data-not-markup case, where the large majority of
+injection bugs arise.
+
+\subsection{Preventing LDAP injection}
+\label{sec:resist:ldap}
+
+LDAP directory queries are the sharpest illustration of the discipline, because
+the language already delimits its structure with a matcher.
+A search filter nests parenthesised assertions, \eg the bind check
+\verb|(&(uid=|\textit{userName}\verb|)(userPassword=|\textit{pass}\verb|))|, and
+the classic vulnerability~\cite{alonso08ldap} is a \verb|userName| that closes its
+assertion early and injects further clauses, as in \verb|*)(uid=*|, so that the
+password assertion no longer constrains the match and the bind succeeds against an
+arbitrary account.
+Where SQL forced us to \emph{introduce} a matcher pair, LDAP needs none: the
+assertion's own parentheses \verb|(uid=|$\dots$\verb|)| already delimit the value,
+so we simply have the directory processor end that value by matcher balance rather
+than at the first \verb|)|.
+
+The canonical injection then fails exactly as before: adapted to the delimiter,
+\verb|*)(uid=*| carries an unmatched \verb|)|, is not matchertext, and cannot
+embed at all.
+A further strength is specific to LDAP: the discipline coincides with the
+language's native syntax, and RFC~4515 value-encoding already escapes unbalanced
+parentheses~\cite{rfc4515}, so a conformant emitter is already close to compliant
+and needs no new hosting form.
+
+\subsection{Preventing PDF object injection}
+\label{sec:resist:pdf}
+
+The same structural argument extends to the PDF document format, whose literal
+strings are delimited by parentheses and, like the PostScript strings they descend
+from, admit balanced parentheses unescaped, requiring an escape only for an
+unmatched parenthesis or backslash~\cite{iso32000}: the format already mandates
+matcher balance for its strings.
+A server-side generator that concatenates untrusted input into a
+\verb|(|$\dots$\verb|)| string, a \verb|/URI (|$\dots$\verb|)|, or a
+\verb|/JS (|$\dots$\verb|)| action lets an attacker close the string and append
+new objects or dictionary keys, adding annotations, actions, or JavaScript that
+Acrobat and browser viewers will parse and run, the ``XSS for PDFs'' class that
+yields script execution, request forgery, and document exfiltration~\cite{heyes20pdf}.
+
+Emitting each untrusted value through \textsc{ToMatchertext} closes this by
+construction.
+Placed in \verb|/URI (|\textit{v}\verb|)|, the canonical breakout
+\begin{center}\footnotesize
+\verb|)>>/AA<</O<</S/JavaScript/JS(app.alert(1))>>>>(|
+\end{center}
+begins with an unmatched \verb|)|, is not matchertext, and is escaped to inert
+data rather than embedded, while a balanced value such as \verb|f(x)| embeds
+unchanged.
+As with SQL and XSS the guarantee is structural and stops at sinks that execute by
+design: data an application deliberately routes into a \verb|/JS| action still
+runs, though it can no longer escape its string to \emph{introduce} one, which is
+where the reported attacks overwhelmingly live.

--- a/injection-research/doc/results.tex
+++ b/injection-research/doc/results.tex
@@ -1,0 +1,73 @@
+\section{Results}
+\label{sec:results}
+
+\begin{table}[t]
+\centering
+\small
+\begin{tabular}{lrr}
+\toprule
+Injection syntax & CVEs & with PoC \\
+\midrule
+HTML / DOM (XSS)    & 50{,}884 & 5{,}207 \\
+SQL                 & 22{,}225 & 5{,}545 \\
+Shell command       &  9{,}672 & 1{,}013 \\
+Code / eval         &  6{,}666 & 1{,}699 \\
+CRLF / header       &    656 &    73 \\
+Argument            &    430 &    39 \\
+\bottomrule
+\end{tabular}
+\caption{Largest injection syntax types, of \(91{,}760\) injection CVEs, with
+the count carrying at least one linked proof-of-concept.}
+\label{tab:syntax}
+\end{table}
+
+\paragraph{Syntax distribution.}
+\Cref{tab:syntax} shows that injection is overwhelmingly concentrated in two
+syntaxes (HTML/DOM and SQL together account for four in five injection CVEs)
+with a long tail of shell, code-eval, header, template, LDAP, XML, and
+formula contexts.
+This concentration matters directly for \cref{sec:prevent}: the two dominant
+syntaxes are exactly the ones a matchertext host can delimit with a matcher pair.
+Exploitation signals are sparse but consistent with severity: 345 injection CVEs
+appear in the CISA Known-Exploited catalog, and command injection, though
+only a tenth of the corpus, carries a disproportionate share of them.
+
+\paragraph{Proof-of-concept coverage.}
+\textbf{13{,}691} injection CVEs (15\%) carry at least one linked PoC.
+The four PoC databases overlap, so unifying them raises payload coverage well
+above any single source. Of these, \textbf{5{,}025} yield an extractable payload; the remainder
+are links only or exploits from which no literal attack string can be recovered, such as modules
+that construct their payload programmatically. This linkage is what makes the prevention analysis
+of \cref{sec:prevent} possible, since it supplies the real attack strings.
+
+\paragraph{Sub-classification.}
+Beyond the two primary axes, each injection CVE is labelled on orthogonal
+facets, each from its strongest available signal, and stored in long form so a
+CVE can carry one label per dimension at once.
+The CVSS vector yields reachability for free: \textbf{50{,}607} injection CVEs
+are exploitable pre-authentication, 28{,}471 require low privilege, and 11{,}085
+high privilege.
+Finer \emph{technique} labels come from PoC payloads and descriptions where
+present: SQL injections resolve into blind-boolean (866), union-based (621),
+blind-time (372), and authentication-bypass (201) attacks, while XSS resolves
+into stored (15{,}559), reflected (6{,}337), and DOM-based (1{,}610).
+
+\paragraph{Syntactic groups.}
+For the \textbf{5{,}025} injection CVEs with an extractable PoC payload, we
+reduce each payload to a \emph{syntactic skeleton}: string literals, numbers,
+and identifiers are abstracted to placeholders (\verb|<q>|, \verb|<n>|,
+\verb|<id>|) while the structural grammar (matchers, operators, tags, and a
+curated set of injection keywords) is preserved.
+Grouping by identical skeleton yields \textbf{2{,}143} distinct groups
+(1{,}817 of them singletons), so specific values never split a group but a
+different breakout structure always does.
+The largest groups are recognizable attack families: the XSS skeletons
+\verb|<TAG>ALERT(DOCUMENT.<id>)</TAG>| (453 CVEs) and its
+\verb|DOCUMENT.COOKIE| variant (231), and the code-eval fragment
+\verb|<? <id>| (110).
+The tail is long: the singletons are 85\% of groups but only 36\% of CVEs, and
+they collapse to fifteen distinct verdicts, since the skeleton preserves tags and
+operators that the containment test does not depend on.
+Because the skeleton preserves exactly the matcher structure while discarding
+values, it is the natural unit on which to test matchertext prevention next: the
+verdict depends only on that structure, so it is shared by every CVE in a group.

--- a/injection-research/doc/threat.tex
+++ b/injection-research/doc/threat.tex
@@ -1,0 +1,136 @@
+\section{Threat model and security property}
+\label{sec:threat}
+
+All the current claims are purely conditional, and this section
+makes the conditions explicit: what is trusted, what the attacker controls, the
+property that is meant to hold, and the deployment premises it requires.
+The property is stated below as an invariant on the host's parse.
+
+\paragraph{Protected asset.}
+For a host program with a hole $P[\cdot]$
+into which an untrusted value $v$ is placed, the asset is the invariant that the
+\emph{structure} of the host's parse of $P[v]$ is independent of the content of
+$v$: the value occupies a single data position and contributes no host syntax.
+
+\paragraph{Trusted computing base.}
+The guarantee rests on (i) a \emph{matchertext-aware host} that delimits the hole
+with a matcher pair and ends the embedded value by matcher balance rather than by
+scanning for its native closer; (ii) the \textsc{Verify} recognizer that decides
+membership in the matchertext language $L$; and (iii) the total encoder
+\textsc{ToMatchertext} and its inverse, used on free-form fields.
+The boundary-locating step of (i) is the operationally load-bearing part; we
+discharge it below as premise L1 (machine checked), so what the host must still be trusted for is the
+\emph{implementation} of that step rather than its principle.
+
+\paragraph{Attacker.}
+The attacker supplies $v$ and may choose \emph{arbitrary} bytes, character
+encodings, Unicode, length, and matcher-nesting depth, and may submit strings
+that are \emph{not} valid matchertext.
+Following Kerckhoffs, the attacker knows the discipline, which delimiter kind
+guards the hole, and where the hole boundaries lie, and crafts $v$ \emph{against}
+the matcher-delimited slot, not the legacy quote or tag-delimited sink that the
+recorded corpus payloads (\cref{sec:results}) target.
+The attacker does not control the host source, the configuration $(\Sigma,\Pi)$,
+or the trusted components above.
+
+\paragraph{Security property (inertness).}
+Let $\textsc{Verify}(v)\Leftrightarrow v\in L$.
+For every host program $P[\cdot]$ and every $v$ with $\textsc{Verify}(v)$, the
+host parse of $P[v]$ places the content of $v$ at a single terminal whose bytes
+do not contribute to the parse structure of $P$; equivalently, the structural
+skeleton of the parse of $P[v]$ is independent of $v$.
+This is strictly stronger than the closure property $s_o\|v\|s_c\in L$ that
+\cref{sec:resist} inherits from the always-embeddability
+theorem~\cite{matchertext}: closure states that the \emph{delimited string
+remains valid matchertext}, whereas inertness states that the \emph{host parser
+treats the delimited content as data}.
+Closure is a lemma toward inertness, not inertness itself: it constrains the
+\emph{string}, not the host \emph{parser}.
+
+\paragraph{Deployment premises.}
+Inertness holds under four assumptions, each necessary:
+\begin{itemize}
+\item[\textbf{A1}] \emph{Aware host.} The sink is a matchertext-aware host that
+	ends the value by matcher balance rather than at its native closer.
+\item[\textbf{A2}] \emph{Delimited context.} Every untrusted value is routed
+	into a matcher-delimited hole; a value concatenated into host syntax
+	outside a hole is unprotected, exactly as with any point-of-use defense.
+\item[\textbf{A3}] \emph{Canonicalize, then verify.} \textsc{Verify} runs on the
+	\emph{fully decoded and normalized} value, at the last transform boundary
+	before it enters the hole, and the host reads that same representation to
+	matcher balance, performing no further decoding, normalization, or
+	reparsing of the hole contents.
+	Writing $\mathrm{canon}(v)$ for the composition of every decode and
+	normalization the pipeline applies, the obligation is
+	$\textsc{Verify}(\mathrm{canon}(v))$ with the host parsing
+	$\mathrm{canon}(v)$; \textsc{Verify} then only needs to track the six literal
+	matcher code points.
+	A check on any earlier, still-encoded representation is unsound: a value
+	valid at that point can acquire an unmatched matcher after a later decode
+	(\eg \verb|%5D|$\rightarrow$\verb|]|) and break out.\footnote{%
+	Making \textsc{Verify} itself robust to \emph{transport} encodings
+	(percent, entity, backslash, \dots) is not viable: those forms compose to
+	unbounded depth and vary by pipeline, reintroducing the parser-shadowing
+	burden matchertext avoids (\cref{sec:bg:sanitizer}).
+	Unicode normalization is the one transform with a finite preimage: exactly
+	20 code points normalize to a \emph{lone} matcher (fullwidth, small,
+	presentation-form, and super/subscript brackets, \eg
+	\texttt{U+FF3B}$\rightarrow$\texttt{[}), while the rest of the preimage
+	normalizes to balanced pairs (\texttt{U+2474}$\rightarrow$\texttt{(1)}) and
+	cannot create an imbalance.
+	Because that set is fixed, canonicalization eliminates it outright, which is
+	why A3 places normalization before the check rather than asking
+	\textsc{Verify} to model it.}
+\item[\textbf{A4}] \emph{Not a semantic sink.} The host does not execute the
+	contained value by design (server-side templates, expression languages,
+	code evaluation, \verb|javascript:| URLs); delimiting confines structure,
+	not meaning.
+\end{itemize}
+
+\paragraph{From closure to inertness.}
+We model the aware host of A1 as a grammar $G$ with one distinguished production
+$\mathit{hole}\rightarrow s_o\,\mathit{content}\,s_c$, where $\mathit{content}$ is
+recovered by the matcher-balance locator and enters $G$ as a single terminal
+whose lexeme is the value in its canonical, fully-decoded form (A3).
+Inertness then rests on three premises, each separately dischargeable:
+\begin{itemize}
+\item[\textbf{L1}] \emph{Boundary.} Reading to matcher balance ends the
+	embedding at the intended position. We prove this
+	(\cref{sec:appendix:lean}): for a matcher-pair-delimited hole and a valid
+	matchertext value $v$, every prefix of $v$ has non-negative matcher depth,
+	$v$ itself returns to depth zero, and the context closer is the first
+	character to drive the depth negative, so the balance boundary is exactly
+	$|v|$. The result is host-\emph{independent} and machine-checked; what
+	remains is the engineering step of verifying a concrete locator
+	implementation (Algorithm~2 of~\cite{matchertext}) against it.
+\item[\textbf{L2}] \emph{Parse inertness.} In $G$ the hole derives exactly one
+	terminal with that lexeme, and no other production derives structure from
+	within it: the parser does not re-enter $G$ on hole content. Reparse-based
+	breakouts such as mutation XSS are exactly L2 violations.
+\item[\textbf{L3}] \emph{Interpreter inertness.} The interpreter binds that
+	terminal as a data value and never re-lexes, reparses, or executes its
+	bytes.
+\end{itemize}
+The chain is then immediate: closure~\cite{matchertext} keeps $P[v]$ a balanced
+matchertext document, so the locator operates on valid input; L1 fixes the hole's
+extent; L2 makes the structural skeleton of $\mathrm{parse}(P[v])$ independent of
+$v$; and L3 carries that independence through to execution.
+Hence $\mathrm{closure}\wedge\mathrm{L1}\wedge\mathrm{L2}\wedge\mathrm{L3}\Rightarrow$
+inertness.
+Closure and the correctness of \textsc{Verify} are machine-checked in the
+underlying formalism~\cite{matchertext}, and we discharge L1 here, once for all
+hosts (\cref{sec:appendix:lean}).
+L2 and L3 are the residual obligations, both per host, and are what the
+implementation work of \cref{sec:concl} must supply.
+
+\paragraph{Scope.}
+\emph{structural} injection are in scope: an attacker-controlled value that alters
+the host parse by escaping its region.
+Out of scope, and excluded from the containment claims throughout, are:
+execution and semantic sinks (A4); contexts delimited by non-matchers with no
+matcher hosting (shell separators, CR/LF header breaks, XML/XXE angle brackets);
+\emph{semantic} abuse in which a well-formed value is merely unauthorized, an
+access-control question; algorithmic denial of service (regular-expression
+backtracking, entity expansion), which is not a breakout; and second-order
+injection in which stored input is reinterpreted later in a different context,
+unless it is re-checked under A3 at that later sink.


### PR DESCRIPTION
Adds the LaTeX draft of the paper (injection-research/doc/): abstract, introduction, motivation, threat model, classification methodology, dataset description, results, matchertext prevention/resistance analysis, and conclusion, plus bibliography and build Makefile. Includes a Lean mechanization of the matcher-balance boundary lemma (L1) in proof.lean.

The empirical results referenced in the draft come from the pipeline submitted in CVE-classification-data.

P.S: needs #27 to be merged first